### PR TITLE
[Do not merge] Make Morbig using POSIX 2018

### DIFF
--- a/src/API.mli
+++ b/src/API.mli
@@ -20,4 +20,4 @@ exception SyntaxError of CST.position * string
    [filename] and returns a concrete syntax tree if [filename] content
    is syntactically correct.
    Raise {SyntaxError (pos, msg)} otherwise. *)
-val parse_file: string -> CST.complete_command_list
+val parse_file: string -> CST.program

--- a/src/CST.ml
+++ b/src/CST.ml
@@ -58,35 +58,26 @@ and 'a located = {
 }
 [@@deriving
    yojson,
-   visitors { variety = "iter";
-              name="located_iter";
-              polymorphic = true },
-   visitors { variety = "map";
-              name="located_map";
-              polymorphic = true },
-   visitors { variety = "reduce";
-              name="located_reduce";
-              polymorphic = true },
-   visitors { variety = "mapreduce";
-              name="located_mapreduce";
-              polymorphic = true },
-   visitors { variety = "iter2";
-              name="located_iter2";
-              polymorphic = true },
-   visitors { variety = "map2";
-              name="located_map2";
-              polymorphic = true },
-   visitors { variety = "reduce2";
-              name="located_reduce2";
-              polymorphic = true }
+   visitors { variety = "iter";      name = "located_iter";      polymorphic = true },
+   visitors { variety = "map";       name = "located_map";       polymorphic = true },
+   visitors { variety = "reduce";    name = "located_reduce";    polymorphic = true },
+   visitors { variety = "mapreduce"; name = "located_mapreduce"; polymorphic = true },
+   visitors { variety = "iter2";     name = "located_iter2";     polymorphic = true },
+   visitors { variety = "map2";      name = "located_map2";      polymorphic = true },
+   visitors { variety = "reduce2";   name = "located_reduce2";   polymorphic = true }
 ]
 
-type complete_command =
-  | CompleteCommand_CList_Separator of clist' * separator'
-  | CompleteCommand_CList of clist'
-  | CompleteCommand_Empty
+type program =
+  | Program_LineBreak_CompleteCommands_LineBreak of linebreak' * complete_commands' * linebreak'
+  | Program_LineBreak of linebreak'
 
-and complete_command_list = complete_command located list
+and complete_commands =
+  | CompleteCommands_CompleteCommands_NewlineList_CompleteCommand of complete_commands' * newline_list' * complete_command'
+  | CompleteCommands_CompleteCommand of complete_command'
+
+and complete_command =
+  | CompleteCommand_CList_SeparatorOp of clist' * separator_op'
+  | CompleteCommand_CList of clist'
 
 and clist =
   (** This non-terminal is called [list] in the grammar but we cannot
@@ -129,11 +120,9 @@ and subshell =
   | Subshell_Lparen_CompoundList_Rparen of compound_list'
 
 and compound_list =
-  | CompoundList_Term of term'
-  | CompoundList_NewLineList_Term of newline_list' * term'
-  | CompoundList_Term_Separator of term' * separator'
-  | CompoundList_NewLineList_Term_Separator of
-      newline_list' * term' * separator'
+  | CompoundList_LineBreak_Term of linebreak' * term'
+  | CompoundList_LineBreak_Term_Separator of
+      linebreak' * term' * separator'
 
 and term =
   | Term_Term_Separator_AndOr of term' * separator' * and_or'
@@ -171,12 +160,12 @@ and case_list =
 and case_item_ns =
   | CaseItemNS_Pattern_Rparen_LineBreak of
       pattern' * linebreak'
-  | CaseItemNS_Pattern_Rparen_CompoundList_LineBreak of
-      pattern' * compound_list' * linebreak'
+  | CaseItemNS_Pattern_Rparen_CompoundList of
+      pattern' * compound_list'
   | CaseItemNS_Lparen_Pattern_Rparen_LineBreak of
       pattern' * linebreak'
-  | CaseItemNS_Lparen_Pattern_Rparen_CompoundList_LineBreak of
-      pattern' * compound_list' * linebreak'
+  | CaseItemNS_Lparen_Pattern_Rparen_CompoundList of
+      pattern' * compound_list'
 
 and case_item =
   | CaseItem_Pattern_Rparen_LineBreak_Dsemi_LineBreak of
@@ -329,7 +318,7 @@ and word = Word of string * word_cst
 and word_cst = word_component list
 
 and word_component =
-  | WordSubshell of subshell_kind * complete_command_list
+  | WordSubshell of subshell_kind * complete_commands
   | WordName of string
   | WordAssignmentWord of assignment_word
   | WordDoubleQuoted of word
@@ -368,10 +357,11 @@ and name = Name of string
 
 and assignment_word = name * word
 
-and assignment_word' = assignment_word located
-
 and io_number = IONumber of string
 
+and program' = program located
+and complete_commands' = complete_commands located
+and complete_command' = complete_command located
 and clist' = clist located
 and and_or' = and_or located
 and pipeline' = pipeline located
@@ -416,7 +406,7 @@ and separator' = separator located
 and sequential_sep' = sequential_sep located
 and word' = word located
 and name' = name located
-and complete_command_list' = complete_command_list located
+and assignment_word' = assignment_word located
 
 [@@deriving
    yojson,

--- a/src/CSTHelpers.ml
+++ b/src/CSTHelpers.ml
@@ -13,11 +13,11 @@
 
 open CST
 
+let program_to_json p =
+  program_to_yojson p
+
 let complete_command_to_json c =
   complete_command_to_yojson c
-
-let complete_command_list_to_json cl =
-  complete_command_list_to_yojson cl
 
 let unWord (Word (s, _)) = s
 
@@ -120,9 +120,9 @@ let string_of_position p =
 let compare_positions p1 p2 =
   compare p1.start_p.pos_cnum p2.start_p.pos_cnum
 
-let nonempty_complete_command c =
-  match c.value with
-  | CompleteCommand_Empty -> false
+let nonempty_program p =
+  match p.value with
+  | Program_LineBreak _ -> false
   | _ -> true
 
 

--- a/src/engine.ml
+++ b/src/engine.ml
@@ -187,9 +187,9 @@ let parse partial (module Lexer : Lexer) =
             match top env with
             | Some (Element (state, v, _, _)) ->
               let analyse_top : type a. a symbol * a -> _ = function
-                | T T_NAME, Name w when is_reserved_word w -> 
+                | T T_NAME, Name w when is_reserved_word w ->
                    parse_error ()
-                | T T_WORD, Word (w, _) when is_reserved_word w -> 
+                | T T_WORD, Word (w, _) when is_reserved_word w ->
                    parse_error ()
                 | _ ->
                   (* By correctness of the underlying LR automaton. *)
@@ -377,7 +377,7 @@ module Lexer (U : sig end) : Lexer = struct
 
   let last_state = ref None
 
-  let copy_position p = 
+  let copy_position p =
     Lexing.{
         pos_fname = p.pos_fname;
         pos_lnum = p.pos_lnum;

--- a/src/jsonHelpers.mli
+++ b/src/jsonHelpers.mli
@@ -14,9 +14,9 @@
 (** [save_as_json simplified oc cst] writes the concrete syntax tree [cst]
     to the out_channel [oc]. If [simplified] is [true] then location
     information is omitted, otherwise it is included in the json output. *)
-val save_as_json: bool -> out_channel -> CST.complete_command_list -> unit
+val save_as_json: bool -> out_channel -> CST.program -> unit
 
 
 (** [save_as_dot oc cst] writes the concrete syntax tree [cst]
     to the out_channel [oc] using the DOT format. *)
-val save_as_dot: out_channel -> CST.complete_command_list -> unit
+val save_as_dot: out_channel -> CST.program -> unit

--- a/src/morbig.ml
+++ b/src/morbig.ml
@@ -13,7 +13,7 @@
 
 open API
 
-let save input_filename (cst : CST.complete_command CST.located list) =
+let save input_filename (cst : CST.program) =
   (** write the concrete syntax tree [cst] to the output file corresponding
       to [input_filename]. The format and and the name of the output file
       are determined by the program options. *)

--- a/src/scripts.mli
+++ b/src/scripts.mli
@@ -24,4 +24,4 @@ val is_elf: string -> bool
 
 (** [parse_file s] attempts to parse the file with name [s], and returns
     its concrete syntax tree. *)
-val parse_file: string -> CST.complete_command_list
+val parse_file: string -> CST.program


### PR DESCRIPTION
It is currently using a mix of POSIX 2013 and POSIX 2018 actually. This implies quite important changes. In particular, there is probably a lot of work to be done in the Engine module, as discussed in #34.

There are still a few cool changes. Most notably, a lot of conflicts in the grammar (that used to be solved with precedence rules) have now disappeared.

I will try to think about what needs to be done in Engine. I wonder if we shouldn't keep `complete_command` as an entry point in the grammar. We would then have a function in Engine that would do all the hard job (this is currently what `parse` does) -- `parse_complete_command`. It would parse one complete command and stop. We would have an other function `parse_program` that would take care (by hand, probably?) of the actual entry point `program`.