### PR TITLE
Add CST helpers

### DIFF
--- a/src/CSTHelpers.mli
+++ b/src/CSTHelpers.mli
@@ -1,0 +1,72 @@
+(**************************************************************************)
+(*  -*- tuareg -*-                                                        *)
+(*                                                                        *)
+(*  Copyright (C) 2017,2018 Yann Régis-Gianas, Nicolas Jeannerod,         *)
+(*  Ralf Treinen.                                                         *)
+(*                                                                        *)
+(*  This is free software: you can redistribute it and/or modify it       *)
+(*  under the terms of the GNU General Public License, version 3.         *)
+(*                                                                        *)
+(*  Additional terms apply, due to the reproduction of portions of        *)
+(*  the POSIX standard. Please refer to the file COPYING for details.     *)
+(**************************************************************************)
+
+open CST
+
+(** {2 Helpers about complete commands} *)
+
+val nonempty_complete_command : complete_command -> bool
+
+val complete_command_to_json : complete_command -> Yojson.Safe.json
+val complete_command_list_to_json : complete_command_list -> Yojson.Safe.json
+
+(** {2 Helpers about words and names} *)
+
+val unWord : word -> string
+val unName : name -> string
+
+val word_of_name : name -> word
+
+val word_of_assignment_word : assignment_word -> word
+
+val string_of_word : word -> string
+
+val word_placeholder : unit -> word' ref
+
+module NameSet : Set.S
+
+(** {2 Helpers about positions} *)
+
+val on_located : ('a -> 'b) -> 'a located -> 'b
+
+val with_pos : position -> 'a -> 'a located
+val with_poss : Lexing.position -> Lexing.position -> 'a -> 'a located
+
+val dummy_lexing_position : Lexing.position
+val dummy_position : position
+
+val start_of_position : position -> Lexing.position
+val end_of_position : position -> Lexing.position
+val filename_of_position : position -> string
+
+val line : Lexing.position -> int
+val column : Lexing.position -> int
+
+val characters : Lexing.position -> Lexing.position -> int * int
+
+val emacs_position : string -> int -> int list -> string
+
+val string_of_lexing_position : Lexing.position -> string
+val string_of_position : position -> string
+
+val compare_positions : position -> position -> int
+
+(** {2 CST destructors} *)
+
+(** [wordlist_of_cmd_suffix] extracts the list of all words from a cmd_sufix *)
+val wordlist_of_cmd_suffix : cmd_suffix -> word' list
+
+val io_redirect_list_of_cmd_prefix : cmd_prefix -> io_redirect' list
+val io_redirect_list_of_cmd_suffix : cmd_suffix -> io_redirect' list
+val io_redirect_list_of_simple_command : simple_command -> io_redirect' list
+val io_redirect_list_of_redirect_list : redirect_list -> io_redirect' list

--- a/src/aliases.ml
+++ b/src/aliases.ml
@@ -73,7 +73,7 @@ let binder_from_alias (x:CST.cmd_suffix) =
   let wl = CSTHelpers.wordlist_of_cmd_suffix x
   in List.fold_right
        (fun a accu ->
-         let s = Str.(bounded_split (regexp "=") (CSTHelpers.unWord a) 2) 
+         let s = Str.(bounded_split (regexp "=") CSTHelpers.(on_located unWord a) 2)
          in if List.length s < 2
             then accu
             else (List.hd s, List.hd (List.tl s)):: accu)
@@ -82,7 +82,7 @@ let binder_from_alias (x:CST.cmd_suffix) =
 
 let unalias_argument (x:CST.cmd_suffix) =
   let wl = CSTHelpers.wordlist_of_cmd_suffix x
-  in List.map CSTHelpers.unWord wl
+  in List.map CSTHelpers.(on_located unWord) wl
 
 let rec as_aliasing_related_command = function
   | SimpleCommand_CmdName_CmdSuffix ({ value = CmdName_Word w }, suffix) ->

--- a/src/engine.ml
+++ b/src/engine.ml
@@ -187,9 +187,9 @@ let parse partial (module Lexer : Lexer) =
             match top env with
             | Some (Element (state, v, _, _)) ->
               let analyse_top : type a. a symbol * a -> _ = function
-                | T T_NAME, Name w when is_reserved_word w -> 
+                | T T_NAME, Name w when is_reserved_word w ->
                    parse_error ()
-                | T T_WORD, Word (w, _) when is_reserved_word w -> 
+                | T T_WORD, Word (w, _) when is_reserved_word w ->
                    parse_error ()
                 | _ ->
                   (* By correctness of the underlying LR automaton. *)
@@ -377,7 +377,7 @@ module Lexer (U : sig end) : Lexer = struct
 
   let last_state = ref None
 
-  let copy_position p = 
+  let copy_position p =
     Lexing.{
         pos_fname = p.pos_fname;
         pos_lnum = p.pos_lnum;
@@ -427,6 +427,6 @@ let parse partial current lexbuf =
   let module Lexer = Lexer (struct end) in
   Lexer.initialize current lexbuf;
   parse partial (module Lexer)
-  |> List.filter CSTHelpers.nonempty_complete_command
+  |> List.filter CSTHelpers.(on_located nonempty_complete_command)
 
 let close_knot = RecursiveParser.parse := (parse true)


### PR DESCRIPTION
This PR starts moving CST helpers from external projects ([colis-anr/lintshell](https://github.com/colis-anr/lintshell) and [colis-anr/shstats](https://github.com/colis-anr/lintshell)) into Morbig. It also add a file `CSTHelpers.mli`.

I used the `_of_` convention since it seemed to be what was used in Morbig mostly (that is, a function transforming a `cmd_prefix` into a list of `io_redirect` will be called `io_redirect_list_of_cmd_prefix`).