### PR TITLE
Fix C example Makefile for Ubuntu

### DIFF
--- a/examples/c/Makefile
+++ b/examples/c/Makefile
@@ -5,7 +5,7 @@ LIBDIR=$(shell ocamlfind query morbig)
 
 all:
 	$(CC) -o dump -I $(STDDIR) -I $(LIBDIR) \
-            dump.c -lm -ldl $(LIBDIR)/libmorbigc.a
+            dump.c $(LIBDIR)/libmorbigc.a -lm -ldl
 
 clean:
 	rm -f dump


### PR DESCRIPTION
This partially fixes #59. Ubuntu uses ld --as-needed by default, which requires that library be placed after the objects that need them. I've changed the order of the linking arguments accordingly, since libmorbigc.a requires -lm and -ldl (now to the right of it).