### PR TITLE
Paramter length bug fix

### DIFF
--- a/src/CST.ml
+++ b/src/CST.ml
@@ -395,7 +395,7 @@ and variable =
 
 and variable_attribute =
   | NoAttribute
-  | ParameterLength of word
+  | ParameterLength 
   | UseDefaultValues of string * word
   | AssignDefaultValues of string * word
   | IndicateErrorifNullorUnset of string * word

--- a/src/prelexer.mll
+++ b/src/prelexer.mll
@@ -462,15 +462,19 @@ rule token current = parse
    Parameter Expansion shall be used to determine the matching '}'.
 
 *)
-  | "${" (parameter_identifier as id) {
+
+| "${#" (parameter_identifier as id) {
   debug ~rule:"parameter-opening-braces" lexbuf current;
   let current = enter_braces current in
-  let attribute =
-    if id = "#" then (* That is a string length. *)
-      ParameterLength (variable_attribute current lexbuf)
-    else
-      close_parameter id current lexbuf
-  in
+  let attribute = ParameterLength in
+  let current = push_parameter ~with_braces:true ~attribute current id in
+  token current lexbuf
+}
+
+| "${" (parameter_identifier as id) {
+  debug ~rule:"parameter-opening-braces" lexbuf current;
+  let current = enter_braces current in
+  let attribute = close_parameter id current lexbuf in
   let current = quit_braces current in
   let current = push_parameter ~with_braces:true ~attribute current id in
   token current lexbuf

--- a/src/prelexerState.ml
+++ b/src/prelexerState.ml
@@ -205,7 +205,7 @@ let push_parameter ?(with_braces=false) ?(attribute=NoAttribute) b id =
   let p =
     if with_braces then
     (* The ParameterLength attribute is a special case.
-     The "#" syntax of the oeprator shows up _before_ the identifier it modifies *)
+     The "#" syntax of the operator shows up _before_ the identifier it modifies. *)
       match attribute with
       | ParameterLength -> "${#" ^ id ^ "}"
       | _ -> "${" ^ id ^ string_of_attribute attribute ^ "}"

--- a/src/prelexerState.ml
+++ b/src/prelexerState.ml
@@ -190,7 +190,7 @@ let string_of_word (Word (s, _)) = s
 
 let string_of_attribute = function
   | NoAttribute -> ""
-  | ParameterLength w -> string_of_word w
+  | ParameterLength -> "#" 
   | UseDefaultValues (p, w) -> p ^ string_of_word w
   | AssignDefaultValues (p, w) -> p ^ string_of_word w
   | IndicateErrorifNullorUnset (p, w) -> p ^ string_of_word w
@@ -204,7 +204,11 @@ let push_parameter ?(with_braces=false) ?(attribute=NoAttribute) b id =
   let v = VariableAtom (id, attribute) in
   let p =
     if with_braces then
-      "${" ^ id ^ string_of_attribute attribute ^ "}"
+    (* The ParameterLength attribute is a special case.
+     The "#" syntax of the oeprator shows up _before_ the identifier it modifies *)
+      match attribute with
+      | ParameterLength -> "${#" ^ id ^ "}"
+      | _ -> "${" ^ id ^ string_of_attribute attribute ^ "}"
     else
       "$" ^ id
   in

--- a/tests/good/2.6-word-expansions/2.6.2-parameter-expansion/basic.sh
+++ b/tests/good/2.6-word-expansions/2.6.2-parameter-expansion/basic.sh
@@ -1,3 +1,4 @@
+${#parameter}
 
 ${parameter:-word}
 

--- a/tests/good/2.6-word-expansions/2.6.2-parameter-expansion/basic.sh.expected
+++ b/tests/good/2.6-word-expansions/2.6.2-parameter-expansion/basic.sh.expected
@@ -16,7 +16,58 @@
               [
                 "CompleteCommands_CompleteCommands_NewlineList_CompleteCommand",
                 [
-                  "CompleteCommands_CompleteCommand",
+                  "CompleteCommands_CompleteCommands_NewlineList_CompleteCommand",
+                  [
+                    "CompleteCommands_CompleteCommand",
+                    [
+                      "CompleteCommand_CList",
+                      [
+                        "CList_AndOr",
+                        [
+                          "AndOr_Pipeline",
+                          [
+                            "Pipeline_PipeSequence",
+                            [
+                              "PipeSequence_Command",
+                              [
+                                "Command_SimpleCommand",
+                                [
+                                  "SimpleCommand_CmdName",
+                                  [
+                                    "CmdName_Word",
+                                    [
+                                      "Word",
+                                      "${#parameter}",
+                                      [
+                                        [
+                                          "WordDoubleQuoted",
+                                          [
+                                            "Word",
+                                            "${#parameter}",
+                                            [
+                                              [
+                                                "WordVariable",
+                                                [
+                                                  "VariableAtom",
+                                                  "parameter",
+                                                  [ "ParameterLength" ]
+                                                ]
+                                              ]
+                                            ]
+                                          ]
+                                        ]
+                                      ]
+                                    ]
+                                  ]
+                                ]
+                              ]
+                            ]
+                          ]
+                        ]
+                      ]
+                    ]
+                  ],
+                  [ "NewLineList_NewLine" ],
                   [
                     "CompleteCommand_CList",
                     [

--- a/tests/good/2.6-word-expansions/2.6.2-parameter-expansion/word-following-variable-parameters.sh.expected
+++ b/tests/good/2.6-word-expansions/2.6.2-parameter-expansion/word-following-variable-parameters.sh.expected
@@ -114,29 +114,17 @@
                                           "${#*}",
                                           [
                                             [
-                                              "WordVariable",
+                                              "WordDoubleQuoted",
                                               [
-                                                "VariableAtom",
-                                                "#",
+                                                "Word",
+                                                "${#*}",
                                                 [
-                                                  "ParameterLength",
                                                   [
-                                                    "Word",
-                                                    "*",
+                                                    "WordVariable",
                                                     [
-                                                      [
-                                                        "WordDoubleQuoted",
-                                                        [
-                                                          "Word",
-                                                          "*",
-                                                          [
-                                                            [
-                                                              "WordLiteral",
-                                                              "*"
-                                                            ]
-                                                          ]
-                                                        ]
-                                                      ]
+                                                      "VariableAtom",
+                                                      "*",
+                                                      [ "ParameterLength" ]
                                                     ]
                                                   ]
                                                 ]
@@ -183,29 +171,17 @@
                                         "${#@}",
                                         [
                                           [
-                                            "WordVariable",
+                                            "WordDoubleQuoted",
                                             [
-                                              "VariableAtom",
-                                              "#",
+                                              "Word",
+                                              "${#@}",
                                               [
-                                                "ParameterLength",
                                                 [
-                                                  "Word",
-                                                  "@",
+                                                  "WordVariable",
                                                   [
-                                                    [
-                                                      "WordDoubleQuoted",
-                                                      [
-                                                        "Word",
-                                                        "@",
-                                                        [
-                                                          [
-                                                            "WordLiteral",
-                                                            "@"
-                                                          ]
-                                                        ]
-                                                      ]
-                                                    ]
+                                                    "VariableAtom",
+                                                    "@",
+                                                    [ "ParameterLength" ]
                                                   ]
                                                 ]
                                               ]
@@ -252,29 +228,17 @@
                                       "${#foo}",
                                       [
                                         [
-                                          "WordVariable",
+                                          "WordDoubleQuoted",
                                           [
-                                            "VariableAtom",
-                                            "#",
+                                            "Word",
+                                            "${#foo}",
                                             [
-                                              "ParameterLength",
                                               [
-                                                "Word",
-                                                "foo",
+                                                "WordVariable",
                                                 [
-                                                  [
-                                                    "WordDoubleQuoted",
-                                                    [
-                                                      "Word",
-                                                      "foo",
-                                                      [
-                                                        [
-                                                          "WordLiteral",
-                                                          "foo"
-                                                        ]
-                                                      ]
-                                                    ]
-                                                  ]
+                                                  "VariableAtom",
+                                                  "foo",
+                                                  [ "ParameterLength" ]
                                                 ]
                                               ]
                                             ]


### PR DESCRIPTION
The Parameter Length attribute is unique amongst parameter expansions (https://pubs.opengroup.org/onlinepubs/009695399/utilities/xcu_chap02.html#tag_02_06_02) in that the parameter identifier occurs _after_ the the operator. (Eg, compare `${#parameter}` with `${parameter:+word}` or `${parameter=word}`. 

Currently, Morbig incorrectly parses the `#` as the identifier name, then puts the actual identifier name in the ParameterLength variable_attribute type. This pull request fixes that.