### PR TITLE
Remove double quotation from parameter

### DIFF
--- a/src/prelexer.mll
+++ b/src/prelexer.mll
@@ -479,7 +479,6 @@ rule token current = parse
 | "}" {
   debug ~rule:"parameter-closing-brace" lexbuf current;
   if under_braces current then
-    let current = pop_quotation OpeningBrace current in
     let _ =   debug ~rule:"parameter-closing-brace-after-pop" lexbuf current in
     return lexbuf current []
   else

--- a/src/prelexerState.ml
+++ b/src/prelexerState.ml
@@ -25,7 +25,7 @@ type atom =
   | QuotingMark of quote_kind
   | AssignmentMark
 
-and quote_kind = SingleQuote | DoubleQuote | OpeningBrace
+and quote_kind = SingleQuote | DoubleQuote
 
 module AtomBuffer : sig
   type t
@@ -265,13 +265,11 @@ let pop_quotation k b =
     match k with
     | SingleQuote -> WordSingleQuoted word
     | DoubleQuote -> WordDoubleQuoted word
-    | OpeningBrace -> WordDoubleQuoted word
   in
   let squote =
     match k with
     | SingleQuote -> "'" ^ squote ^ "'"
     | DoubleQuote -> "\"" ^ squote ^ "\""
-    | OpeningBrace -> squote
   in
   let quote = WordComponent (squote, quoted_word) in
   let buffer = AtomBuffer.make (quote :: buffer) in

--- a/tests/good/2.6-word-expansions/2.6.2-parameter-expansion/basic.sh.expected
+++ b/tests/good/2.6-word-expansions/2.6.2-parameter-expansion/basic.sh.expected
@@ -48,20 +48,7 @@
                                             [
                                               "Word",
                                               "word",
-                                              [
-                                                [
-                                                  "WordDoubleQuoted",
-                                                  [
-                                                    "Word",
-                                                    "word",
-                                                    [
-                                                      [
-                                                        "WordLiteral", "word"
-                                                      ]
-                                                    ]
-                                                  ]
-                                                ]
-                                              ]
+                                              [ [ "WordLiteral", "word" ] ]
                                             ]
                                           ]
                                         ]
@@ -109,18 +96,7 @@
                                           [
                                             "Word",
                                             "word",
-                                            [
-                                              [
-                                                "WordDoubleQuoted",
-                                                [
-                                                  "Word",
-                                                  "word",
-                                                  [
-                                                    [ "WordLiteral", "word" ]
-                                                  ]
-                                                ]
-                                              ]
-                                            ]
+                                            [ [ "WordLiteral", "word" ] ]
                                           ]
                                         ]
                                       ]
@@ -168,16 +144,7 @@
                                         [
                                           "Word",
                                           "word",
-                                          [
-                                            [
-                                              "WordDoubleQuoted",
-                                              [
-                                                "Word",
-                                                "word",
-                                                [ [ "WordLiteral", "word" ] ]
-                                              ]
-                                            ]
-                                          ]
+                                          [ [ "WordLiteral", "word" ] ]
                                         ]
                                       ]
                                     ]
@@ -225,16 +192,7 @@
                                       [
                                         "Word",
                                         "word",
-                                        [
-                                          [
-                                            "WordDoubleQuoted",
-                                            [
-                                              "Word",
-                                              "word",
-                                              [ [ "WordLiteral", "word" ] ]
-                                            ]
-                                          ]
-                                        ]
+                                        [ [ "WordLiteral", "word" ] ]
                                       ]
                                     ]
                                   ]
@@ -282,16 +240,7 @@
                                     [
                                       "Word",
                                       "word",
-                                      [
-                                        [
-                                          "WordDoubleQuoted",
-                                          [
-                                            "Word",
-                                            "word",
-                                            [ [ "WordLiteral", "word" ] ]
-                                          ]
-                                        ]
-                                      ]
+                                      [ [ "WordLiteral", "word" ] ]
                                     ]
                                   ]
                                 ]
@@ -339,16 +288,7 @@
                                   [
                                     "Word",
                                     "word",
-                                    [
-                                      [
-                                        "WordDoubleQuoted",
-                                        [
-                                          "Word",
-                                          "word",
-                                          [ [ "WordLiteral", "word" ] ]
-                                        ]
-                                      ]
-                                    ]
+                                    [ [ "WordLiteral", "word" ] ]
                                   ]
                                 ]
                               ]
@@ -396,16 +336,7 @@
                                 [
                                   "Word",
                                   "word",
-                                  [
-                                    [
-                                      "WordDoubleQuoted",
-                                      [
-                                        "Word",
-                                        "word",
-                                        [ [ "WordLiteral", "word" ] ]
-                                      ]
-                                    ]
-                                  ]
+                                  [ [ "WordLiteral", "word" ] ]
                                 ]
                               ]
                             ]
@@ -453,16 +384,7 @@
                               [
                                 "Word",
                                 "word",
-                                [
-                                  [
-                                    "WordDoubleQuoted",
-                                    [
-                                      "Word",
-                                      "word",
-                                      [ [ "WordLiteral", "word" ] ]
-                                    ]
-                                  ]
-                                ]
+                                [ [ "WordLiteral", "word" ] ]
                               ]
                             ]
                           ]

--- a/tests/good/2.6-word-expansions/2.6.2-parameter-expansion/operator-in-parameter.sh.expected
+++ b/tests/good/2.6-word-expansions/2.6.2-parameter-expansion/operator-in-parameter.sh.expected
@@ -41,16 +41,7 @@
                                       [
                                         "Word",
                                         "<<?",
-                                        [
-                                          [
-                                            "WordDoubleQuoted",
-                                            [
-                                              "Word",
-                                              "<<?",
-                                              [ [ "WordLiteral", "<<?" ] ]
-                                            ]
-                                          ]
-                                        ]
+                                        [ [ "WordLiteral", "<<?" ] ]
                                       ]
                                     ]
                                   ]

--- a/tests/good/2.6-word-expansions/2.6.2-parameter-expansion/recursive.sh.expected
+++ b/tests/good/2.6-word-expansions/2.6.2-parameter-expansion/recursive.sh.expected
@@ -36,58 +36,49 @@
                                 "$(echo foo)",
                                 [
                                   [
-                                    "WordDoubleQuoted",
+                                    "WordSubshell",
+                                    [ "SubShellKindParentheses" ],
                                     [
-                                      "Word",
-                                      "$(echo foo)",
+                                      "Program_LineBreak_CompleteCommands_LineBreak",
+                                      [ "LineBreak_Empty" ],
                                       [
+                                        "CompleteCommands_CompleteCommand",
                                         [
-                                          "WordSubshell",
-                                          [ "SubShellKindParentheses" ],
+                                          "CompleteCommand_CList",
                                           [
-                                            "Program_LineBreak_CompleteCommands_LineBreak",
-                                            [ "LineBreak_Empty" ],
+                                            "CList_AndOr",
                                             [
-                                              "CompleteCommands_CompleteCommand",
+                                              "AndOr_Pipeline",
                                               [
-                                                "CompleteCommand_CList",
+                                                "Pipeline_PipeSequence",
                                                 [
-                                                  "CList_AndOr",
+                                                  "PipeSequence_Command",
                                                   [
-                                                    "AndOr_Pipeline",
+                                                    "Command_SimpleCommand",
                                                     [
-                                                      "Pipeline_PipeSequence",
+                                                      "SimpleCommand_CmdName_CmdSuffix",
                                                       [
-                                                        "PipeSequence_Command",
+                                                        "CmdName_Word",
                                                         [
-                                                          "Command_SimpleCommand",
+                                                          "Word",
+                                                          "echo",
                                                           [
-                                                            "SimpleCommand_CmdName_CmdSuffix",
                                                             [
-                                                              "CmdName_Word",
-                                                              [
-                                                                "Word",
-                                                                "echo",
-                                                                [
-                                                                  [
-                                                                    "WordName",
-                                                                    "echo"
-                                                                  ]
-                                                                ]
-                                                              ]
-                                                            ],
+                                                              "WordName",
+                                                              "echo"
+                                                            ]
+                                                          ]
+                                                        ]
+                                                      ],
+                                                      [
+                                                        "CmdSuffix_Word",
+                                                        [
+                                                          "Word",
+                                                          "foo",
+                                                          [
                                                             [
-                                                              "CmdSuffix_Word",
-                                                              [
-                                                                "Word",
-                                                                "foo",
-                                                                [
-                                                                  [
-                                                                    "WordName",
-                                                                    "foo"
-                                                                  ]
-                                                                ]
-                                                              ]
+                                                              "WordName",
+                                                              "foo"
                                                             ]
                                                           ]
                                                         ]
@@ -96,11 +87,11 @@
                                                   ]
                                                 ]
                                               ]
-                                            ],
-                                            [ "LineBreak_Empty" ]
+                                            ]
                                           ]
                                         ]
-                                      ]
+                                      ],
+                                      [ "LineBreak_Empty" ]
                                     ]
                                   ]
                                 ]

--- a/tests/good/2.6-word-expansions/2.6.2-parameter-expansion/vicious.sh.expected
+++ b/tests/good/2.6-word-expansions/2.6.2-parameter-expansion/vicious.sh.expected
@@ -66,23 +66,14 @@
                                                               "'}'",
                                                               [
                                                                 [
-                                                                  "WordDoubleQuoted",
+                                                                  "WordSingleQuoted",
                                                                   [
-                                                                    "Word",
-                                                                    "'}'",
-                                                                    [
-                                                                    [
-                                                                    "WordSingleQuoted",
-                                                                    [
                                                                     "Word",
                                                                     "}",
                                                                     [
                                                                     [
                                                                     "WordLiteral",
                                                                     "}"
-                                                                    ]
-                                                                    ]
-                                                                    ]
                                                                     ]
                                                                     ]
                                                                   ]
@@ -137,17 +128,8 @@
                                                             "\\}",
                                                             [
                                                               [
-                                                                "WordDoubleQuoted",
-                                                                [
-                                                                  "Word",
-                                                                  "\\}",
-                                                                  [
-                                                                    [
-                                                                    "WordLiteral",
-                                                                    "\\}"
-                                                                    ]
-                                                                  ]
-                                                                ]
+                                                                "WordLiteral",
+                                                                "\\}"
                                                               ]
                                                             ]
                                                           ]
@@ -199,23 +181,14 @@
                                                           "'}'",
                                                           [
                                                             [
-                                                              "WordDoubleQuoted",
+                                                              "WordSingleQuoted",
                                                               [
                                                                 "Word",
-                                                                "'}'",
+                                                                "}",
                                                                 [
                                                                   [
-                                                                    "WordSingleQuoted",
-                                                                    [
-                                                                    "Word",
-                                                                    "}",
-                                                                    [
-                                                                    [
                                                                     "WordLiteral",
                                                                     "}"
-                                                                    ]
-                                                                    ]
-                                                                    ]
                                                                   ]
                                                                 ]
                                                               ]
@@ -270,17 +243,8 @@
                                                         "\\}",
                                                         [
                                                           [
-                                                            "WordDoubleQuoted",
-                                                            [
-                                                              "Word",
-                                                              "\\}",
-                                                              [
-                                                                [
-                                                                  "WordLiteral",
-                                                                  "\\}"
-                                                                ]
-                                                              ]
-                                                            ]
+                                                            "WordLiteral",
+                                                            "\\}"
                                                           ]
                                                         ]
                                                       ]
@@ -332,23 +296,14 @@
                                                       "'}'",
                                                       [
                                                         [
-                                                          "WordDoubleQuoted",
+                                                          "WordSingleQuoted",
                                                           [
                                                             "Word",
-                                                            "'}'",
+                                                            "}",
                                                             [
                                                               [
-                                                                "WordSingleQuoted",
-                                                                [
-                                                                  "Word",
-                                                                  "}",
-                                                                  [
-                                                                    [
-                                                                    "WordLiteral",
-                                                                    "}"
-                                                                    ]
-                                                                  ]
-                                                                ]
+                                                                "WordLiteral",
+                                                                "}"
                                                               ]
                                                             ]
                                                           ]
@@ -403,17 +358,7 @@
                                                     "\\}",
                                                     [
                                                       [
-                                                        "WordDoubleQuoted",
-                                                        [
-                                                          "Word",
-                                                          "\\}",
-                                                          [
-                                                            [
-                                                              "WordLiteral",
-                                                              "\\}"
-                                                            ]
-                                                          ]
-                                                        ]
+                                                        "WordLiteral", "\\}"
                                                       ]
                                                     ]
                                                   ]
@@ -465,23 +410,14 @@
                                                   "'}'",
                                                   [
                                                     [
-                                                      "WordDoubleQuoted",
+                                                      "WordSingleQuoted",
                                                       [
                                                         "Word",
-                                                        "'}'",
+                                                        "}",
                                                         [
                                                           [
-                                                            "WordSingleQuoted",
-                                                            [
-                                                              "Word",
-                                                              "}",
-                                                              [
-                                                                [
-                                                                  "WordLiteral",
-                                                                  "}"
-                                                                ]
-                                                              ]
-                                                            ]
+                                                            "WordLiteral",
+                                                            "}"
                                                           ]
                                                         ]
                                                       ]
@@ -534,21 +470,7 @@
                                               [
                                                 "Word",
                                                 "\\}",
-                                                [
-                                                  [
-                                                    "WordDoubleQuoted",
-                                                    [
-                                                      "Word",
-                                                      "\\}",
-                                                      [
-                                                        [
-                                                          "WordLiteral",
-                                                          "\\}"
-                                                        ]
-                                                      ]
-                                                    ]
-                                                  ]
-                                                ]
+                                                [ [ "WordLiteral", "\\}" ] ]
                                               ]
                                             ]
                                           ]
@@ -598,24 +520,12 @@
                                               "'}'",
                                               [
                                                 [
-                                                  "WordDoubleQuoted",
+                                                  "WordSingleQuoted",
                                                   [
                                                     "Word",
-                                                    "'}'",
+                                                    "}",
                                                     [
-                                                      [
-                                                        "WordSingleQuoted",
-                                                        [
-                                                          "Word",
-                                                          "}",
-                                                          [
-                                                            [
-                                                              "WordLiteral",
-                                                              "}"
-                                                            ]
-                                                          ]
-                                                        ]
-                                                      ]
+                                                      [ "WordLiteral", "}" ]
                                                     ]
                                                   ]
                                                 ]
@@ -667,18 +577,7 @@
                                           [
                                             "Word",
                                             "\\}",
-                                            [
-                                              [
-                                                "WordDoubleQuoted",
-                                                [
-                                                  "Word",
-                                                  "\\}",
-                                                  [
-                                                    [ "WordLiteral", "\\}" ]
-                                                  ]
-                                                ]
-                                              ]
-                                            ]
+                                            [ [ "WordLiteral", "\\}" ] ]
                                           ]
                                         ]
                                       ]
@@ -728,24 +627,11 @@
                                           "'}'",
                                           [
                                             [
-                                              "WordDoubleQuoted",
+                                              "WordSingleQuoted",
                                               [
                                                 "Word",
-                                                "'}'",
-                                                [
-                                                  [
-                                                    "WordSingleQuoted",
-                                                    [
-                                                      "Word",
-                                                      "}",
-                                                      [
-                                                        [
-                                                          "WordLiteral", "}"
-                                                        ]
-                                                      ]
-                                                    ]
-                                                  ]
-                                                ]
+                                                "}",
+                                                [ [ "WordLiteral", "}" ] ]
                                               ]
                                             ]
                                           ]
@@ -796,16 +682,7 @@
                                       [
                                         "Word",
                                         "\\}",
-                                        [
-                                          [
-                                            "WordDoubleQuoted",
-                                            [
-                                              "Word",
-                                              "\\}",
-                                              [ [ "WordLiteral", "\\}" ] ]
-                                            ]
-                                          ]
-                                        ]
+                                        [ [ "WordLiteral", "\\}" ] ]
                                       ]
                                     ]
                                   ]
@@ -855,20 +732,11 @@
                                       "'}'",
                                       [
                                         [
-                                          "WordDoubleQuoted",
+                                          "WordSingleQuoted",
                                           [
                                             "Word",
-                                            "'}'",
-                                            [
-                                              [
-                                                "WordSingleQuoted",
-                                                [
-                                                  "Word",
-                                                  "}",
-                                                  [ [ "WordLiteral", "}" ] ]
-                                                ]
-                                              ]
-                                            ]
+                                            "}",
+                                            [ [ "WordLiteral", "}" ] ]
                                           ]
                                         ]
                                       ]
@@ -919,16 +787,7 @@
                                   [
                                     "Word",
                                     "\\}",
-                                    [
-                                      [
-                                        "WordDoubleQuoted",
-                                        [
-                                          "Word",
-                                          "\\}",
-                                          [ [ "WordLiteral", "\\}" ] ]
-                                        ]
-                                      ]
-                                    ]
+                                    [ [ "WordLiteral", "\\}" ] ]
                                   ]
                                 ]
                               ]
@@ -978,20 +837,11 @@
                                   "'}'",
                                   [
                                     [
-                                      "WordDoubleQuoted",
+                                      "WordSingleQuoted",
                                       [
                                         "Word",
-                                        "'}'",
-                                        [
-                                          [
-                                            "WordSingleQuoted",
-                                            [
-                                              "Word",
-                                              "}",
-                                              [ [ "WordLiteral", "}" ] ]
-                                            ]
-                                          ]
-                                        ]
+                                        "}",
+                                        [ [ "WordLiteral", "}" ] ]
                                       ]
                                     ]
                                   ]
@@ -1039,20 +889,7 @@
                             [
                               "UseAlternativeValue",
                               "+",
-                              [
-                                "Word",
-                                "\\}",
-                                [
-                                  [
-                                    "WordDoubleQuoted",
-                                    [
-                                      "Word",
-                                      "\\}",
-                                      [ [ "WordLiteral", "\\}" ] ]
-                                    ]
-                                  ]
-                                ]
-                              ]
+                              [ "Word", "\\}", [ [ "WordLiteral", "\\}" ] ] ]
                             ]
                           ]
                         ]

--- a/tests/good/2.6-word-expansions/2.6.2-parameter-expansion/with-spaces.sh.expected
+++ b/tests/good/2.6-word-expansions/2.6.2-parameter-expansion/with-spaces.sh.expected
@@ -48,18 +48,7 @@
                                             [
                                               "Word",
                                               " ",
-                                              [
-                                                [
-                                                  "WordDoubleQuoted",
-                                                  [
-                                                    "Word",
-                                                    " ",
-                                                    [
-                                                      [ "WordLiteral", " " ]
-                                                    ]
-                                                  ]
-                                                ]
-                                              ]
+                                              [ [ "WordLiteral", " " ] ]
                                             ]
                                           ]
                                         ]
@@ -107,16 +96,7 @@
                                           [
                                             "Word",
                                             " ",
-                                            [
-                                              [
-                                                "WordDoubleQuoted",
-                                                [
-                                                  "Word",
-                                                  " ",
-                                                  [ [ "WordLiteral", " " ] ]
-                                                ]
-                                              ]
-                                            ]
+                                            [ [ "WordLiteral", " " ] ]
                                           ]
                                         ]
                                       ]
@@ -164,16 +144,7 @@
                                         [
                                           "Word",
                                           " ",
-                                          [
-                                            [
-                                              "WordDoubleQuoted",
-                                              [
-                                                "Word",
-                                                " ",
-                                                [ [ "WordLiteral", " " ] ]
-                                              ]
-                                            ]
-                                          ]
+                                          [ [ "WordLiteral", " " ] ]
                                         ]
                                       ]
                                     ]
@@ -221,16 +192,7 @@
                                       [
                                         "Word",
                                         " ",
-                                        [
-                                          [
-                                            "WordDoubleQuoted",
-                                            [
-                                              "Word",
-                                              " ",
-                                              [ [ "WordLiteral", " " ] ]
-                                            ]
-                                          ]
-                                        ]
+                                        [ [ "WordLiteral", " " ] ]
                                       ]
                                     ]
                                   ]
@@ -278,16 +240,7 @@
                                     [
                                       "Word",
                                       " ",
-                                      [
-                                        [
-                                          "WordDoubleQuoted",
-                                          [
-                                            "Word",
-                                            " ",
-                                            [ [ "WordLiteral", " " ] ]
-                                          ]
-                                        ]
-                                      ]
+                                      [ [ "WordLiteral", " " ] ]
                                     ]
                                   ]
                                 ]
@@ -332,20 +285,7 @@
                                 [
                                   "IndicateErrorifNullorUnset",
                                   "?",
-                                  [
-                                    "Word",
-                                    " ",
-                                    [
-                                      [
-                                        "WordDoubleQuoted",
-                                        [
-                                          "Word",
-                                          " ",
-                                          [ [ "WordLiteral", " " ] ]
-                                        ]
-                                      ]
-                                    ]
-                                  ]
+                                  [ "Word", " ", [ [ "WordLiteral", " " ] ] ]
                                 ]
                               ]
                             ]
@@ -389,20 +329,7 @@
                               [
                                 "UseAlternativeValue",
                                 ":+",
-                                [
-                                  "Word",
-                                  " ",
-                                  [
-                                    [
-                                      "WordDoubleQuoted",
-                                      [
-                                        "Word",
-                                        " ",
-                                        [ [ "WordLiteral", " " ] ]
-                                      ]
-                                    ]
-                                  ]
-                                ]
+                                [ "Word", " ", [ [ "WordLiteral", " " ] ] ]
                               ]
                             ]
                           ]
@@ -446,20 +373,7 @@
                             [
                               "UseAlternativeValue",
                               "+",
-                              [
-                                "Word",
-                                " ",
-                                [
-                                  [
-                                    "WordDoubleQuoted",
-                                    [
-                                      "Word",
-                                      " ",
-                                      [ [ "WordLiteral", " " ] ]
-                                    ]
-                                  ]
-                                ]
-                              ]
+                              [ "Word", " ", [ [ "WordLiteral", " " ] ] ]
                             ]
                           ]
                         ]

--- a/tests/good/2.6-word-expansions/2.6.2-parameter-expansion/word-following-variable-parameters.sh.expected
+++ b/tests/good/2.6-word-expansions/2.6.2-parameter-expansion/word-following-variable-parameters.sh.expected
@@ -124,19 +124,7 @@
                                                     "Word",
                                                     "*",
                                                     [
-                                                      [
-                                                        "WordDoubleQuoted",
-                                                        [
-                                                          "Word",
-                                                          "*",
-                                                          [
-                                                            [
-                                                              "WordLiteral",
-                                                              "*"
-                                                            ]
-                                                          ]
-                                                        ]
-                                                      ]
+                                                      [ "WordLiteral", "*" ]
                                                     ]
                                                   ]
                                                 ]
@@ -192,21 +180,7 @@
                                                 [
                                                   "Word",
                                                   "@",
-                                                  [
-                                                    [
-                                                      "WordDoubleQuoted",
-                                                      [
-                                                        "Word",
-                                                        "@",
-                                                        [
-                                                          [
-                                                            "WordLiteral",
-                                                            "@"
-                                                          ]
-                                                        ]
-                                                      ]
-                                                    ]
-                                                  ]
+                                                  [ [ "WordLiteral", "@" ] ]
                                                 ]
                                               ]
                                             ]
@@ -261,21 +235,7 @@
                                               [
                                                 "Word",
                                                 "foo",
-                                                [
-                                                  [
-                                                    "WordDoubleQuoted",
-                                                    [
-                                                      "Word",
-                                                      "foo",
-                                                      [
-                                                        [
-                                                          "WordLiteral",
-                                                          "foo"
-                                                        ]
-                                                      ]
-                                                    ]
-                                                  ]
-                                                ]
+                                                [ [ "WordLiteral", "foo" ] ]
                                               ]
                                             ]
                                           ]
@@ -330,20 +290,7 @@
                                             [
                                               "Word",
                                               "\n\n",
-                                              [
-                                                [
-                                                  "WordDoubleQuoted",
-                                                  [
-                                                    "Word",
-                                                    "\n\n",
-                                                    [
-                                                      [
-                                                        "WordLiteral", "\n\n"
-                                                      ]
-                                                    ]
-                                                  ]
-                                                ]
-                                              ]
+                                              [ [ "WordLiteral", "\n\n" ] ]
                                             ]
                                           ]
                                         ]
@@ -447,24 +394,11 @@
                                           "'}'",
                                           [
                                             [
-                                              "WordDoubleQuoted",
+                                              "WordSingleQuoted",
                                               [
                                                 "Word",
-                                                "'}'",
-                                                [
-                                                  [
-                                                    "WordSingleQuoted",
-                                                    [
-                                                      "Word",
-                                                      "}",
-                                                      [
-                                                        [
-                                                          "WordLiteral", "}"
-                                                        ]
-                                                      ]
-                                                    ]
-                                                  ]
-                                                ]
+                                                "}",
+                                                [ [ "WordLiteral", "}" ] ]
                                               ]
                                             ]
                                           ]
@@ -523,19 +457,8 @@
                                             "WordDoubleQuoted",
                                             [
                                               "Word",
-                                              "\"}\"",
-                                              [
-                                                [
-                                                  "WordDoubleQuoted",
-                                                  [
-                                                    "Word",
-                                                    "}",
-                                                    [
-                                                      [ "WordLiteral", "}" ]
-                                                    ]
-                                                  ]
-                                                ]
-                                              ]
+                                              "}",
+                                              [ [ "WordLiteral", "}" ] ]
                                             ]
                                           ]
                                         ]
@@ -589,16 +512,7 @@
                                     [
                                       "Word",
                                       "\\}",
-                                      [
-                                        [
-                                          "WordDoubleQuoted",
-                                          [
-                                            "Word",
-                                            "\\}",
-                                            [ [ "WordLiteral", "\\}" ] ]
-                                          ]
-                                        ]
-                                      ]
+                                      [ [ "WordLiteral", "\\}" ] ]
                                     ]
                                   ]
                                 ]
@@ -654,17 +568,8 @@
                                         "WordDoubleQuoted",
                                         [
                                           "Word",
-                                          "\"foo}\"",
-                                          [
-                                            [
-                                              "WordDoubleQuoted",
-                                              [
-                                                "Word",
-                                                "foo}",
-                                                [ [ "WordLiteral", "foo}" ] ]
-                                              ]
-                                            ]
-                                          ]
+                                          "foo}",
+                                          [ [ "WordLiteral", "foo}" ] ]
                                         ]
                                       ]
                                     ]
@@ -718,16 +623,7 @@
                                 [
                                   "Word",
                                   "for",
-                                  [
-                                    [
-                                      "WordDoubleQuoted",
-                                      [
-                                        "Word",
-                                        "for",
-                                        [ [ "WordLiteral", "for" ] ]
-                                      ]
-                                    ]
-                                  ]
+                                  [ [ "WordLiteral", "for" ] ]
                                 ]
                               ]
                             ]


### PR DESCRIPTION
Right now, an extra set of double quotes surrounds every parameter. This pull request fixes that.

Test plan:

```
[ishaangandhi@Ishaans-MacBook-Pro-5.local ~/Develop/morbig]$ make check
if command -v ocamlopt >/dev/null; then cp src/c/dune.native src/c/dune; fi
dune build @install
Done: 0/0 (jobs: 0)[ -e bin ] || ln -sf _build/install/default/bin bin
[ -e lib ] || ln -sf _build/install/default/lib/morbig lib
* Testsuite configuration
Using local /Users/ishaangandhi/Develop/morbig/bin/morbig.
* Summary:
-----------------------------------
| Tests | Passed | Failed | Total |
|-------|--------|--------|-------|
| good  |    110 |      0 |   110 | 
| bad   |     67 |      0 |    67 |
| all   |    177 |      0 |   177 |
-----------------------------------

         ----------------
         Congratulations!
         ----------------
```