### PR TITLE
Update copyright to 2021

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,7 +1,7 @@
 License and copyright information for morbig
 ============================================
 
-Copyright (C) 2017,2018 Yann Régis-Gianas, Nicolas Jeannerod, Ralf Treinen.
+Copyright (C) 2017-2021 Yann Régis-Gianas, Nicolas Jeannerod, Ralf Treinen.
 
 Morbig is free software: you can redistribute it and/or modify it
 under the terms of the GNU General Public License, version 3. The

--- a/src/.header
+++ b/src/.header
@@ -1,6 +1,6 @@
 -*- tuareg -*-
 
-Copyright (C) 2017,2018,2019 Yann Régis-Gianas, Nicolas Jeannerod,
+Copyright (C) 2017-2021 Yann Régis-Gianas, Nicolas Jeannerod,
 Ralf Treinen.
 
 This is free software: you can redistribute it and/or modify it

--- a/src/API.ml
+++ b/src/API.ml
@@ -1,7 +1,7 @@
 (**************************************************************************)
 (*  -*- tuareg -*-                                                        *)
 (*                                                                        *)
-(*  Copyright (C) 2017,2018,2019 Yann Régis-Gianas, Nicolas Jeannerod,    *)
+(*  Copyright (C) 2017-2021 Yann Régis-Gianas, Nicolas Jeannerod,         *)
 (*  Ralf Treinen.                                                         *)
 (*                                                                        *)
 (*  This is free software: you can redistribute it and/or modify it       *)

--- a/src/API.mli
+++ b/src/API.mli
@@ -1,7 +1,7 @@
 (**************************************************************************)
 (*  -*- tuareg -*-                                                        *)
 (*                                                                        *)
-(*  Copyright (C) 2017,2018,2019 Yann Régis-Gianas, Nicolas Jeannerod,    *)
+(*  Copyright (C) 2017-2021 Yann Régis-Gianas, Nicolas Jeannerod,         *)
 (*  Ralf Treinen.                                                         *)
 (*                                                                        *)
 (*  This is free software: you can redistribute it and/or modify it       *)

--- a/src/CST.ml
+++ b/src/CST.ml
@@ -1,7 +1,7 @@
 (**************************************************************************)
 (*  -*- tuareg -*-                                                        *)
 (*                                                                        *)
-(*  Copyright (C) 2017,2018,2019 Yann Régis-Gianas, Nicolas Jeannerod,    *)
+(*  Copyright (C) 2017-2021 Yann Régis-Gianas, Nicolas Jeannerod,         *)
 (*  Ralf Treinen.                                                         *)
 (*                                                                        *)
 (*  This is free software: you can redistribute it and/or modify it       *)

--- a/src/CSTHelpers.ml
+++ b/src/CSTHelpers.ml
@@ -1,7 +1,7 @@
 (**************************************************************************)
 (*  -*- tuareg -*-                                                        *)
 (*                                                                        *)
-(*  Copyright (C) 2017,2018,2019 Yann Régis-Gianas, Nicolas Jeannerod,    *)
+(*  Copyright (C) 2017-2021 Yann Régis-Gianas, Nicolas Jeannerod,         *)
 (*  Ralf Treinen.                                                         *)
 (*                                                                        *)
 (*  This is free software: you can redistribute it and/or modify it       *)

--- a/src/CSTHelpers.mli
+++ b/src/CSTHelpers.mli
@@ -1,7 +1,7 @@
 (**************************************************************************)
 (*  -*- tuareg -*-                                                        *)
 (*                                                                        *)
-(*  Copyright (C) 2017,2018,2019 Yann Régis-Gianas, Nicolas Jeannerod,    *)
+(*  Copyright (C) 2017-2021 Yann Régis-Gianas, Nicolas Jeannerod,         *)
 (*  Ralf Treinen.                                                         *)
 (*                                                                        *)
 (*  This is free software: you can redistribute it and/or modify it       *)

--- a/src/ExtMenhirLib.ml
+++ b/src/ExtMenhirLib.ml
@@ -1,7 +1,7 @@
 (**************************************************************************)
 (*  -*- tuareg -*-                                                        *)
 (*                                                                        *)
-(*  Copyright (C) 2017,2018,2019 Yann Régis-Gianas, Nicolas Jeannerod,    *)
+(*  Copyright (C) 2017-2021 Yann Régis-Gianas, Nicolas Jeannerod,         *)
 (*  Ralf Treinen.                                                         *)
 (*                                                                        *)
 (*  This is free software: you can redistribute it and/or modify it       *)

--- a/src/REBracketExpressionLexer.mll
+++ b/src/REBracketExpressionLexer.mll
@@ -1,6 +1,6 @@
 (** -*- tuareg -*- ********************************************************)
 (*                                                                        *)
-(*  Copyright (C) 2017-2019 Yann Régis-Gianas, Nicolas Jeannerod,         *)
+(*  Copyright (C) 2017-2021 Yann Régis-Gianas, Nicolas Jeannerod,         *)
 (*  Ralf Treinen.                                                         *)
 (*                                                                        *)
 (*  This is free software: you can redistribute it and/or modify it       *)

--- a/src/REBracketExpressionParser.mly
+++ b/src/REBracketExpressionParser.mly
@@ -1,6 +1,6 @@
 /**  -*- tuareg -*- *******************************************************/
 /*                                                                        */
-/*  Copyright (C) 2017,2018 Yann Régis-Gianas, Nicolas Jeannerod,         */
+/*  Copyright (C) 2017-2021 Yann Régis-Gianas, Nicolas Jeannerod,         */
 /*  Ralf Treinen.                                                         */
 /*                                                                        */
 /*  This is free software: you can redistribute it and/or modify it       */

--- a/src/aliases.ml
+++ b/src/aliases.ml
@@ -1,7 +1,7 @@
 (**************************************************************************)
 (*  -*- tuareg -*-                                                        *)
 (*                                                                        *)
-(*  Copyright (C) 2017,2018,2019 Yann Régis-Gianas, Nicolas Jeannerod,    *)
+(*  Copyright (C) 2017-2021 Yann Régis-Gianas, Nicolas Jeannerod,         *)
 (*  Ralf Treinen.                                                         *)
 (*                                                                        *)
 (*  This is free software: you can redistribute it and/or modify it       *)

--- a/src/aliases.mli
+++ b/src/aliases.mli
@@ -1,7 +1,7 @@
 (**************************************************************************)
 (*  -*- tuareg -*-                                                        *)
 (*                                                                        *)
-(*  Copyright (C) 2017,2018,2019 Yann Régis-Gianas, Nicolas Jeannerod,    *)
+(*  Copyright (C) 2017-2021 Yann Régis-Gianas, Nicolas Jeannerod,         *)
 (*  Ralf Treinen.                                                         *)
 (*                                                                        *)
 (*  This is free software: you can redistribute it and/or modify it       *)

--- a/src/assignment.ml
+++ b/src/assignment.ml
@@ -1,7 +1,7 @@
 (**************************************************************************)
 (*  -*- tuareg -*-                                                        *)
 (*                                                                        *)
-(*  Copyright (C) 2017,2018,2019 Yann Régis-Gianas, Nicolas Jeannerod,    *)
+(*  Copyright (C) 2017-2021 Yann Régis-Gianas, Nicolas Jeannerod,         *)
 (*  Ralf Treinen.                                                         *)
 (*                                                                        *)
 (*  This is free software: you can redistribute it and/or modify it       *)

--- a/src/c/CAPI.ml
+++ b/src/c/CAPI.ml
@@ -1,7 +1,7 @@
 (**************************************************************************)
 (*  -*- tuareg -*-                                                        *)
 (*                                                                        *)
-(*  Copyright (C) 2017,2018,2019 Yann Régis-Gianas, Nicolas Jeannerod,    *)
+(*  Copyright (C) 2017-2021 Yann Régis-Gianas, Nicolas Jeannerod,         *)
 (*  Ralf Treinen.                                                         *)
 (*                                                                        *)
 (*  This is free software: you can redistribute it and/or modify it       *)

--- a/src/c/cstub.c
+++ b/src/c/cstub.c
@@ -1,6 +1,6 @@
 /*
 
-  Copyright (C) 2017,2018 Yann Régis-Gianas, Nicolas Jeannerod,
+  Copyright (C) 2017-2021 Yann Régis-Gianas, Nicolas Jeannerod,
   Ralf Treinen.
 
   This is free software: you can redistribute it and/or modify it

--- a/src/c/cstub.h
+++ b/src/c/cstub.h
@@ -1,6 +1,6 @@
 /*
 
-  Copyright (C) 2017,2018 Yann Régis-Gianas, Nicolas Jeannerod,
+  Copyright (C) 2017-2021 Yann Régis-Gianas, Nicolas Jeannerod,
   Ralf Treinen.
 
   This is free software: you can redistribute it and/or modify it

--- a/src/c/cstub.ml
+++ b/src/c/cstub.ml
@@ -1,7 +1,7 @@
 (**************************************************************************)
 (*  -*- tuareg -*-                                                        *)
 (*                                                                        *)
-(*  Copyright (C) 2017,2018,2019 Yann Régis-Gianas, Nicolas Jeannerod,    *)
+(*  Copyright (C) 2017-2021 Yann Régis-Gianas, Nicolas Jeannerod,         *)
 (*  Ralf Treinen.                                                         *)
 (*                                                                        *)
 (*  This is free software: you can redistribute it and/or modify it       *)

--- a/src/debug.ml
+++ b/src/debug.ml
@@ -1,7 +1,7 @@
 (**************************************************************************)
 (*  -*- tuareg -*-                                                        *)
 (*                                                                        *)
-(*  Copyright (C) 2017,2018,2019 Yann Régis-Gianas, Nicolas Jeannerod,    *)
+(*  Copyright (C) 2017-2021 Yann Régis-Gianas, Nicolas Jeannerod,         *)
 (*  Ralf Treinen.                                                         *)
 (*                                                                        *)
 (*  This is free software: you can redistribute it and/or modify it       *)

--- a/src/engine.ml
+++ b/src/engine.ml
@@ -1,7 +1,7 @@
 (**************************************************************************)
 (*  -*- tuareg -*-                                                        *)
 (*                                                                        *)
-(*  Copyright (C) 2017,2018,2019 Yann Régis-Gianas, Nicolas Jeannerod,    *)
+(*  Copyright (C) 2017-2021 Yann Régis-Gianas, Nicolas Jeannerod,         *)
 (*  Ralf Treinen.                                                         *)
 (*                                                                        *)
 (*  This is free software: you can redistribute it and/or modify it       *)

--- a/src/errors.ml
+++ b/src/errors.ml
@@ -1,7 +1,7 @@
 (**************************************************************************)
 (*  -*- tuareg -*-                                                        *)
 (*                                                                        *)
-(*  Copyright (C) 2017,2018,2019 Yann Régis-Gianas, Nicolas Jeannerod,    *)
+(*  Copyright (C) 2017-2021 Yann Régis-Gianas, Nicolas Jeannerod,         *)
 (*  Ralf Treinen.                                                         *)
 (*                                                                        *)
 (*  This is free software: you can redistribute it and/or modify it       *)

--- a/src/errors.mli
+++ b/src/errors.mli
@@ -1,7 +1,7 @@
 (**************************************************************************)
 (*  -*- tuareg -*-                                                        *)
 (*                                                                        *)
-(*  Copyright (C) 2017,2018,2019 Yann Régis-Gianas, Nicolas Jeannerod,    *)
+(*  Copyright (C) 2017-2021 Yann Régis-Gianas, Nicolas Jeannerod,         *)
 (*  Ralf Treinen.                                                         *)
 (*                                                                        *)
 (*  This is free software: you can redistribute it and/or modify it       *)

--- a/src/extPervasives.ml
+++ b/src/extPervasives.ml
@@ -1,7 +1,7 @@
 (**************************************************************************)
 (*  -*- tuareg -*-                                                        *)
 (*                                                                        *)
-(*  Copyright (C) 2017,2018,2019 Yann Régis-Gianas, Nicolas Jeannerod,    *)
+(*  Copyright (C) 2017-2021 Yann Régis-Gianas, Nicolas Jeannerod,         *)
 (*  Ralf Treinen.                                                         *)
 (*                                                                        *)
 (*  This is free software: you can redistribute it and/or modify it       *)

--- a/src/hereDocument.ml
+++ b/src/hereDocument.ml
@@ -1,7 +1,7 @@
 (**************************************************************************)
 (*  -*- tuareg -*-                                                        *)
 (*                                                                        *)
-(*  Copyright (C) 2017,2018,2019 Yann Régis-Gianas, Nicolas Jeannerod,    *)
+(*  Copyright (C) 2017-2021 Yann Régis-Gianas, Nicolas Jeannerod,         *)
 (*  Ralf Treinen.                                                         *)
 (*                                                                        *)
 (*  This is free software: you can redistribute it and/or modify it       *)

--- a/src/hereDocument.mli
+++ b/src/hereDocument.mli
@@ -1,7 +1,7 @@
 (**************************************************************************)
 (*  -*- tuareg -*-                                                        *)
 (*                                                                        *)
-(*  Copyright (C) 2017,2018,2019 Yann Régis-Gianas, Nicolas Jeannerod,    *)
+(*  Copyright (C) 2017-2021 Yann Régis-Gianas, Nicolas Jeannerod,         *)
 (*  Ralf Treinen.                                                         *)
 (*                                                                        *)
 (*  This is free software: you can redistribute it and/or modify it       *)

--- a/src/jsonHelpers.ml
+++ b/src/jsonHelpers.ml
@@ -1,7 +1,7 @@
 (**************************************************************************)
 (*  -*- tuareg -*-                                                        *)
 (*                                                                        *)
-(*  Copyright (C) 2017,2018,2019 Yann Régis-Gianas, Nicolas Jeannerod,    *)
+(*  Copyright (C) 2017-2021 Yann Régis-Gianas, Nicolas Jeannerod,         *)
 (*  Ralf Treinen.                                                         *)
 (*                                                                        *)
 (*  This is free software: you can redistribute it and/or modify it       *)

--- a/src/jsonHelpers.mli
+++ b/src/jsonHelpers.mli
@@ -1,7 +1,7 @@
 (**************************************************************************)
 (*  -*- tuareg -*-                                                        *)
 (*                                                                        *)
-(*  Copyright (C) 2017,2018,2019 Yann Régis-Gianas, Nicolas Jeannerod,    *)
+(*  Copyright (C) 2017-2021 Yann Régis-Gianas, Nicolas Jeannerod,         *)
 (*  Ralf Treinen.                                                         *)
 (*                                                                        *)
 (*  This is free software: you can redistribute it and/or modify it       *)

--- a/src/keyword.ml
+++ b/src/keyword.ml
@@ -1,7 +1,7 @@
 (**************************************************************************)
 (*  -*- tuareg -*-                                                        *)
 (*                                                                        *)
-(*  Copyright (C) 2017,2018,2019 Yann Régis-Gianas, Nicolas Jeannerod,    *)
+(*  Copyright (C) 2017-2021 Yann Régis-Gianas, Nicolas Jeannerod,         *)
 (*  Ralf Treinen.                                                         *)
 (*                                                                        *)
 (*  This is free software: you can redistribute it and/or modify it       *)

--- a/src/morbig.ml
+++ b/src/morbig.ml
@@ -1,7 +1,7 @@
 (**************************************************************************)
 (*  -*- tuareg -*-                                                        *)
 (*                                                                        *)
-(*  Copyright (C) 2017,2018,2019 Yann Régis-Gianas, Nicolas Jeannerod,    *)
+(*  Copyright (C) 2017-2021 Yann Régis-Gianas, Nicolas Jeannerod,         *)
 (*  Ralf Treinen.                                                         *)
 (*                                                                        *)
 (*  This is free software: you can redistribute it and/or modify it       *)

--- a/src/morbigDriver.ml
+++ b/src/morbigDriver.ml
@@ -1,7 +1,7 @@
 (**************************************************************************)
 (*  -*- tuareg -*-                                                        *)
 (*                                                                        *)
-(*  Copyright (C) 2017,2018,2019 Yann Régis-Gianas, Nicolas Jeannerod,    *)
+(*  Copyright (C) 2017-2021 Yann Régis-Gianas, Nicolas Jeannerod,         *)
 (*  Ralf Treinen.                                                         *)
 (*                                                                        *)
 (*  This is free software: you can redistribute it and/or modify it       *)

--- a/src/name.ml
+++ b/src/name.ml
@@ -1,7 +1,7 @@
 (**************************************************************************)
 (*  -*- tuareg -*-                                                        *)
 (*                                                                        *)
-(*  Copyright (C) 2017,2018,2019 Yann Régis-Gianas, Nicolas Jeannerod,    *)
+(*  Copyright (C) 2017-2021 Yann Régis-Gianas, Nicolas Jeannerod,         *)
 (*  Ralf Treinen.                                                         *)
 (*                                                                        *)
 (*  This is free software: you can redistribute it and/or modify it       *)

--- a/src/nesting.ml
+++ b/src/nesting.ml
@@ -1,7 +1,7 @@
 (**************************************************************************)
 (*  -*- tuareg -*-                                                        *)
 (*                                                                        *)
-(*  Copyright (C) 2017,2018,2019 Yann Régis-Gianas, Nicolas Jeannerod,    *)
+(*  Copyright (C) 2017-2021 Yann Régis-Gianas, Nicolas Jeannerod,         *)
 (*  Ralf Treinen.                                                         *)
 (*                                                                        *)
 (*  This is free software: you can redistribute it and/or modify it       *)

--- a/src/nesting.mli
+++ b/src/nesting.mli
@@ -1,7 +1,7 @@
 (**************************************************************************)
 (*  -*- tuareg -*-                                                        *)
 (*                                                                        *)
-(*  Copyright (C) 2017,2018,2019 Yann Régis-Gianas, Nicolas Jeannerod,    *)
+(*  Copyright (C) 2017-2021 Yann Régis-Gianas, Nicolas Jeannerod,         *)
 (*  Ralf Treinen.                                                         *)
 (*                                                                        *)
 (*  This is free software: you can redistribute it and/or modify it       *)

--- a/src/options.ml
+++ b/src/options.ml
@@ -1,7 +1,7 @@
 (**************************************************************************)
 (*  -*- tuareg -*-                                                        *)
 (*                                                                        *)
-(*  Copyright (C) 2017,2018,2019 Yann Régis-Gianas, Nicolas Jeannerod,    *)
+(*  Copyright (C) 2017-2021 Yann Régis-Gianas, Nicolas Jeannerod,         *)
 (*  Ralf Treinen.                                                         *)
 (*                                                                        *)
 (*  This is free software: you can redistribute it and/or modify it       *)

--- a/src/options.mli
+++ b/src/options.mli
@@ -1,7 +1,7 @@
 (**************************************************************************)
 (*  -*- tuareg -*-                                                        *)
 (*                                                                        *)
-(*  Copyright (C) 2017,2018,2019 Yann Régis-Gianas, Nicolas Jeannerod,    *)
+(*  Copyright (C) 2017-2021 Yann Régis-Gianas, Nicolas Jeannerod,         *)
 (*  Ralf Treinen.                                                         *)
 (*                                                                        *)
 (*  This is free software: you can redistribute it and/or modify it       *)

--- a/src/parser.mly
+++ b/src/parser.mly
@@ -1,6 +1,6 @@
 /**  -*- tuareg -*- *******************************************************/
 /*                                                                        */
-/*  Copyright (C) 2017,2018,2019 Yann Régis-Gianas, Nicolas Jeannerod,    */
+/*  Copyright (C) 2017-2021 Yann Régis-Gianas, Nicolas Jeannerod,         */
 /*  Ralf Treinen.                                                         */
 /*                                                                        */
 /*  This is free software: you can redistribute it and/or modify it       */

--- a/src/patternMatchingRecognizer.ml
+++ b/src/patternMatchingRecognizer.ml
@@ -1,7 +1,7 @@
 (**************************************************************************)
 (*  -*- tuareg -*-                                                        *)
 (*                                                                        *)
-(*  Copyright (C) 2017-2019 Yann Régis-Gianas, Nicolas Jeannerod,         *)
+(*  Copyright (C) 2017-2021 Yann Régis-Gianas, Nicolas Jeannerod,         *)
 (*  Ralf Treinen.                                                         *)
 (*                                                                        *)
 (*  This is free software: you can redistribute it and/or modify it       *)

--- a/src/prelexer.mli
+++ b/src/prelexer.mli
@@ -1,7 +1,7 @@
 (**************************************************************************)
 (*  -*- tuareg -*-                                                        *)
 (*                                                                        *)
-(*  Copyright (C) 2017,2018,2019 Yann Régis-Gianas, Nicolas Jeannerod,    *)
+(*  Copyright (C) 2017-2021 Yann Régis-Gianas, Nicolas Jeannerod,         *)
 (*  Ralf Treinen.                                                         *)
 (*                                                                        *)
 (*  This is free software: you can redistribute it and/or modify it       *)

--- a/src/prelexer.mll
+++ b/src/prelexer.mll
@@ -1,6 +1,6 @@
 (** -*- tuareg -*- ********************************************************)
 (*                                                                        *)
-(*  Copyright (C) 2017,2018,2019 Yann Régis-Gianas, Nicolas Jeannerod,    *)
+(*  Copyright (C) 2017-2021 Yann Régis-Gianas, Nicolas Jeannerod,         *)
 (*  Ralf Treinen.                                                         *)
 (*                                                                        *)
 (*  This is free software: you can redistribute it and/or modify it       *)

--- a/src/prelexerState.ml
+++ b/src/prelexerState.ml
@@ -1,7 +1,7 @@
 (**************************************************************************)
 (*  -*- tuareg -*-                                                        *)
 (*                                                                        *)
-(*  Copyright (C) 2017,2018,2019 Yann Régis-Gianas, Nicolas Jeannerod,    *)
+(*  Copyright (C) 2017-2021 Yann Régis-Gianas, Nicolas Jeannerod,         *)
 (*  Ralf Treinen.                                                         *)
 (*                                                                        *)
 (*  This is free software: you can redistribute it and/or modify it       *)

--- a/src/pretoken.ml
+++ b/src/pretoken.ml
@@ -1,7 +1,7 @@
 (**************************************************************************)
 (*  -*- tuareg -*-                                                        *)
 (*                                                                        *)
-(*  Copyright (C) 2017,2018,2019 Yann Régis-Gianas, Nicolas Jeannerod,    *)
+(*  Copyright (C) 2017-2021 Yann Régis-Gianas, Nicolas Jeannerod,         *)
 (*  Ralf Treinen.                                                         *)
 (*                                                                        *)
 (*  This is free software: you can redistribute it and/or modify it       *)

--- a/src/pretokenizer.ml
+++ b/src/pretokenizer.ml
@@ -1,7 +1,7 @@
 (**************************************************************************)
 (*  -*- tuareg -*-                                                        *)
 (*                                                                        *)
-(*  Copyright (C) 2017,2018,2019 Yann Régis-Gianas, Nicolas Jeannerod,    *)
+(*  Copyright (C) 2017-2021 Yann Régis-Gianas, Nicolas Jeannerod,         *)
 (*  Ralf Treinen.                                                         *)
 (*                                                                        *)
 (*  This is free software: you can redistribute it and/or modify it       *)

--- a/src/quoteRemoval.ml
+++ b/src/quoteRemoval.ml
@@ -1,7 +1,7 @@
 (**************************************************************************)
 (*  -*- tuareg -*-                                                        *)
 (*                                                                        *)
-(*  Copyright (C) 2017,2018,2019 Yann Régis-Gianas, Nicolas Jeannerod,    *)
+(*  Copyright (C) 2017-2021 Yann Régis-Gianas, Nicolas Jeannerod,         *)
 (*  Ralf Treinen.                                                         *)
 (*                                                                        *)
 (*  This is free software: you can redistribute it and/or modify it       *)

--- a/src/recursiveParser.ml
+++ b/src/recursiveParser.ml
@@ -1,7 +1,7 @@
 (**************************************************************************)
 (*  -*- tuareg -*-                                                        *)
 (*                                                                        *)
-(*  Copyright (C) 2017,2018,2019 Yann Régis-Gianas, Nicolas Jeannerod,    *)
+(*  Copyright (C) 2017-2021 Yann Régis-Gianas, Nicolas Jeannerod,         *)
 (*  Ralf Treinen.                                                         *)
 (*                                                                        *)
 (*  This is free software: you can redistribute it and/or modify it       *)

--- a/src/scripts.ml
+++ b/src/scripts.ml
@@ -1,7 +1,7 @@
 (**************************************************************************)
 (*  -*- tuareg -*-                                                        *)
 (*                                                                        *)
-(*  Copyright (C) 2017,2018,2019 Yann Régis-Gianas, Nicolas Jeannerod,    *)
+(*  Copyright (C) 2017-2021 Yann Régis-Gianas, Nicolas Jeannerod,         *)
 (*  Ralf Treinen.                                                         *)
 (*                                                                        *)
 (*  This is free software: you can redistribute it and/or modify it       *)

--- a/src/scripts.mli
+++ b/src/scripts.mli
@@ -1,7 +1,7 @@
 (**************************************************************************)
 (*  -*- tuareg -*-                                                        *)
 (*                                                                        *)
-(*  Copyright (C) 2017,2018,2019 Yann Régis-Gianas, Nicolas Jeannerod,    *)
+(*  Copyright (C) 2017-2021 Yann Régis-Gianas, Nicolas Jeannerod,         *)
 (*  Ralf Treinen.                                                         *)
 (*                                                                        *)
 (*  This is free software: you can redistribute it and/or modify it       *)

--- a/src/tildePrefix.ml
+++ b/src/tildePrefix.ml
@@ -1,7 +1,7 @@
 (**************************************************************************)
 (*  -*- tuareg -*-                                                        *)
 (*                                                                        *)
-(*  Copyright (C) 2017,2018,2019 Yann Régis-Gianas, Nicolas Jeannerod,    *)
+(*  Copyright (C) 2017-2021 Yann Régis-Gianas, Nicolas Jeannerod,         *)
 (*  Ralf Treinen.                                                         *)
 (*                                                                        *)
 (*  This is free software: you can redistribute it and/or modify it       *)

--- a/src/token.ml
+++ b/src/token.ml
@@ -1,7 +1,7 @@
 (**************************************************************************)
 (*  -*- tuareg -*-                                                        *)
 (*                                                                        *)
-(*  Copyright (C) 2017,2018,2019 Yann Régis-Gianas, Nicolas Jeannerod,    *)
+(*  Copyright (C) 2017-2021 Yann Régis-Gianas, Nicolas Jeannerod,         *)
 (*  Ralf Treinen.                                                         *)
 (*                                                                        *)
 (*  This is free software: you can redistribute it and/or modify it       *)


### PR DESCRIPTION
This PR updates the copyright notices so that they all include `2017-2021` instead of the various forms:

- `2017,2018`
- `2017,2018,2019`
- `2017-2019`