### PR TITLE
Also build examples in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,17 +15,17 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-        ocaml-version:
-          - 4.05.0
-          - 4.06.1
-          - 4.07.1
-          - 4.08.1
-          - 4.09.1
-          - 4.10.2
-          - 4.11.2
+        # ocaml-version:
+        #   - 4.05.0
+        #   - 4.06.1
+        #   - 4.07.1
+        #   - 4.08.1
+        #   - 4.09.1
+        #   - 4.10.2
+        #   - 4.11.2
         include:
-          - { os: ubuntu-latest,  ocaml-version: 4.12.0, deploy-doc: deploy-doc }
-          - { os: macos-latest,   ocaml-version: 4.12.0 }
+          # - { os: ubuntu-latest,  ocaml-version: 4.12.0, deploy-doc: deploy-doc }
+          # - { os: macos-latest,   ocaml-version: 4.12.0 }
           - { os: windows-latest, ocaml-version: 4.12.0 }
 
     runs-on: ${{ matrix.os }}
@@ -151,45 +151,45 @@ jobs:
 
   ## ======================== [ Docker-based CI ] ======================== ##
 
-  docker-based:
+  # docker-based:
 
-    strategy:
-      fail-fast: false
-      matrix:
-        tag:
-          - centos
-          - debian
-          - debian-testing
-          - debian-unstable
-          - opensuse
-          - ubuntu
-          - ubuntu-lts
-        include:
-          - { tag: alpine, deploy-image: deploy-image }
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       tag:
+  #         - centos
+  #         - debian
+  #         - debian-testing
+  #         - debian-unstable
+  #         - opensuse
+  #         - ubuntu
+  #         - ubuntu-lts
+  #       include:
+  #         - { tag: alpine, deploy-image: deploy-image }
 
-    runs-on: ubuntu-latest
+  #   runs-on: ubuntu-latest
 
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v2
+  #   steps:
+  #     - name: Checkout Repository
+  #       uses: actions/checkout@v2
 
-      - name: Build Docker Image
-        run: docker build . --tag morbig --build-arg tag=${{matrix.tag}}
+  #     - name: Build Docker Image
+  #       run: docker build . --tag morbig --build-arg tag=${{matrix.tag}}
 
-      - name: Run Tests
-        run: docker run --entrypoint /bin/sh morbig -c 'eval $(opam env) && cd /home/opam/morbig && make check && make install && make examples && make uninstall'
+  #     - name: Run Tests
+  #       run: docker run --entrypoint /bin/sh morbig -c 'eval $(opam env) && cd /home/opam/morbig && make check && make install && make examples && make uninstall'
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
-        if: github.event_name == 'push' && matrix.deploy-image == 'deploy-image'
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v1
+  #       with:
+  #         username: ${{ secrets.DOCKER_HUB_USERNAME }}
+  #         password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+  #       if: github.event_name == 'push' && matrix.deploy-image == 'deploy-image'
 
-      - name: Rename Docker Image
-        run: docker image tag morbig colisanr/morbig:${GITHUB_REF##*/}
-        if: github.event_name == 'push' && matrix.deploy-image == 'deploy-image'
+  #     - name: Rename Docker Image
+  #       run: docker image tag morbig colisanr/morbig:${GITHUB_REF##*/}
+  #       if: github.event_name == 'push' && matrix.deploy-image == 'deploy-image'
 
-      - name: Push to Docker Hub
-        run: docker push colisanr/morbig:${GITHUB_REF##*/}
-        if: github.event_name == 'push' && matrix.deploy-image == 'deploy-image'
+  #     - name: Push to Docker Hub
+  #       run: docker push colisanr/morbig:${GITHUB_REF##*/}
+  #       if: github.event_name == 'push' && matrix.deploy-image == 'deploy-image'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,8 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-        # ocaml-version:
-        #   - 4.05.0
+        ocaml-version:
+          - 4.05.0
         #   - 4.06.1
         #   - 4.07.1
         #   - 4.08.1
@@ -39,14 +39,28 @@ jobs:
         with:
           ocaml-version: ${{ matrix.ocaml-version }}
 
-      - name: Install Dune
-        run: opam install dune --yes
-
-      - name: Install OPAM Dependencies
+      - name: Install Dune/OPAM Dependencies
         run: |
+          opam install dune --yes
           opam exec -- dune build || true
-          opam install . --yes --deps-only --with-doc --with-test
-        ## FIXME: The caught failure of dune build is here to mitigate #4487.
+          for pkg in $(opam show . --field=name); do
+            opam pin $pkg.dev . --no-action
+            opam depext $pkg --yes --with-doc --with-test
+            opam install $pkg --yes --deps-only --with-doc --with-test
+          done
+          ## FIXME: The caught failure of dune build is here to mitigate #4487.
+        if: runner.os != 'Windows'
+
+      - name: Install Dune/OPAM Dependencies (Windows)
+        run: |
+          opam install dune --yes
+          opam exec -- dune build
+          opam show . --field=name | ForEach {
+            opam pin $_.dev . --no-action
+            opam depext $_ --yes --with-doc --with-test
+            opam install $_ --yes --deps-only --with-doc --with-test
+          }
+        if: runner.os == 'Windows'
 
       - name: Try Building
         run: opam exec -- make

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,9 @@ jobs:
       - name: Try Installing
         run: opam exec -- make install
 
+      - name: Try Building Examples
+        run: opam exec -- make examples
+
       - name: Try Uninstalling
         run: opam exec -- make uninstall
 
@@ -104,6 +107,9 @@ jobs:
 
       - name: Try Installing
         run: sudo make install
+
+      - name: Try Building Examples
+        run: make examples
 
       - name: Try Uninstalling
         run: sudo make uninstall

--- a/morbig.opam
+++ b/morbig.opam
@@ -25,7 +25,7 @@ bug-reports: "https://github.com/colis-anr/morbig/issues"
 dev-repo: "git://github.com/colis-anr/morbig.git"
 
 depexts: [
-  ["mingw64-x86_64-dlfcn"] {os = "cygwin"}
+  ["dlfcn" "flexdll"]    {os = "win32"}
 ]
 
 depends: [

--- a/morbig.opam
+++ b/morbig.opam
@@ -24,6 +24,10 @@ homepage: "https://github.com/colis-anr/morbig"
 bug-reports: "https://github.com/colis-anr/morbig/issues"
 dev-repo: "git://github.com/colis-anr/morbig.git"
 
+depexts: [
+  ["mingw64-x86_64-dlfcn"] {os = "cygwin"}
+]
+
 depends: [
   "dune"                 {build & >= "1.4.0"}
   "menhir"               {>= "20170509"}


### PR DESCRIPTION
I forgot that `make check` does not build the C examples which are our only way to test the C API. One has to try running `make examples` after having installed the software. This used to be checked in the Docker CI (and is thus still here in the Docker-based part of our CI) but I did not reproduce this behaviour in the newly introduced "APT-based" and "OPAM-based" CIs. This PR fixes that.

It is currently WIP as I suspect it might not work on Windows (we've had problems before). When the CI is fixed, I'll re-run the job and check that it indeed works on Windows (or fix it).