### PR TITLE
Update the minimal version for Yojson

### DIFF
--- a/morbig.opam
+++ b/morbig.opam
@@ -31,7 +31,7 @@ depends: [
   "odoc"                 {with-doc}
   "ppx_deriving_yojson"
   "visitors"             {>= "20180513"}
-  "yojson"
+  "yojson"               {>= "1.6.0"}
 ]
 
 build: ["dune" "build" "-p" name "-j" jobs]


### PR DESCRIPTION
`Yojson.Safe.t` was added in Yojson 1.6.0 and while I am going through the reverse dependencies of Yojson for the upcoming 2.0 release it seems reasonable to update that constraint.