### PR TITLE
Remove Brew-based CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,36 +119,6 @@ jobs:
       # - name: Try Cleaning
       #   run: make clean
 
-  ## ========================= [ Brew-based CI ] ========================= ##
-
-  brew-based:
-    runs-on: macos-latest
-
-    steps:
-      - name: Install OCaml & Dependencies
-        run: brew install ocaml dune menhir odoc ppx_deriving_yojson visitors yojson
-
-      - name: Checkout Repository
-        uses: actions/checkout@v2
-
-      - name: Try Building
-        run: make
-
-      - name: Try Building Documentation
-        run: make doc
-
-      - name: Run Tests
-        run: make check
-
-      - name: Try Installing
-        run: make install
-
-      - name: Try Uninstalling
-        run: make uninstall
-
-      - name: Try Cleaning
-        run: make clean
-
   ## ======================== [ Docker-based CI ] ======================== ##
 
   docker-based:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,36 +120,34 @@ jobs:
       #   run: make clean
 
   ## ========================= [ Brew-based CI ] ========================= ##
-  ## Sadly, the right dependencies do not exist in brew and therefore we cannot
-  ## provide a purely brew-based installation process.
 
-  # brew-based:
-  #   runs-on: macos-latest
+  brew-based:
+    runs-on: macos-latest
 
-  #   steps:
-  #     - name: Install OCaml & Dependencies
-  #       run: brew install ocaml dune menhir odoc ppx_deriving_yojson visitors yojson
+    steps:
+      - name: Install OCaml & Dependencies
+        run: brew install ocaml dune menhir odoc ppx_deriving_yojson visitors yojson
 
-  #     - name: Checkout Repository
-  #       uses: actions/checkout@v2
+      - name: Checkout Repository
+        uses: actions/checkout@v2
 
-  #     - name: Try Building
-  #       run: make
+      - name: Try Building
+        run: make
 
-  #     - name: Try Building Documentation
-  #       run: make doc
+      - name: Try Building Documentation
+        run: make doc
 
-  #     - name: Run Tests
-  #       run: make check
+      - name: Run Tests
+        run: make check
 
-  #     - name: Try Installing
-  #       run: make install
+      - name: Try Installing
+        run: make install
 
-  #     - name: Try Uninstalling
-  #       run: make uninstall
+      - name: Try Uninstalling
+        run: make uninstall
 
-  #     - name: Try Cleaning
-  #       run: make clean
+      - name: Try Cleaning
+        run: make clean
 
   ## ======================== [ Docker-based CI ] ======================== ##
 


### PR DESCRIPTION
Started as: ~Remove Brew-based CI~.

closes #138 

builds on top of #136 

~clashes a bit with #141; we should build one on top of the other and also build examples in Brew-based CI. For now, I'm basically just checking if it works.~