### PR TITLE
Publish documentation using GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,9 +85,7 @@ jobs:
 
       - name: Deploy to GitHub pages
         uses: actions/deploy-pages@v1
-        ## FIXME: For testing purposes, we allow many more events to deploy pages.
-        if: matrix.deploy-doc == 'deploy-doc'
-        # if: github.event_name == 'push' && github.ref == 'refs/heads/main' && matrix.deploy-doc == 'deploy-doc'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && matrix.deploy-doc == 'deploy-doc'
 
   ## ========================= [ APT-based CI ] ========================== ##
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,10 @@ jobs:
           - { os: macos-latest,   ocaml-version: 4.14.x }
           - { os: windows-latest, ocaml-version: 4.14.x }
 
+    ## Grant GITHUB_TOKEN the permissions required to make a pages deployment
+    permissions:
+      pages: write
+
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,13 +72,17 @@ jobs:
 
       - name: Build Documentation for Auto-Deploy
         run: opam exec -- make doc
-        if: github.event_name == 'push' && matrix.deploy-doc == 'deploy-doc'
 
-      - name: Auto-Deploy Documentation
-        uses: Niols/deploy-odoc-action@main
+      - name: Upload documentation artifact
+        uses: actions/upload-pages-artifact@v1
         with:
-          GENERATED_DOC_DIR: doc/
-        if: github.event_name == 'push' && matrix.deploy-doc == 'deploy-doc'
+          path: doc/
+
+      - name: Deploy to GitHub pages
+        uses: actions/deploy-pages@v1
+        ## FIXME: For testing purposes, we allow many more events to deploy pages.
+        if: matrix.deploy-doc == 'deploy-doc'
+        # if: github.event_name == 'push' && github.ref == 'refs/heads/main' && matrix.deploy-doc == 'deploy-doc'
 
   ## ========================= [ APT-based CI ] ========================== ##
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
     ## Grant GITHUB_TOKEN the permissions required to make a pages deployment
     permissions:
       pages: write
+      id-token: write
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
We use the new way of publishing the documentation.

Documentation for tags is already available through https://ocaml.org/p/morbig/latest/doc/ anyways.