### PR TITLE
Cleanup useless files

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -1,7 +1,0 @@
-S src
-B src/_build
-PKG yojson
-PKG ppx_deriving_yojson
-PKG visitors.ppx
-PKG visitors.runtime
-PKG menhirLib

--- a/META
+++ b/META
@@ -1,7 +1,0 @@
-name="morbig"
-version="0.9"
-description="API of Morbig, a POSIX shell parser"
-requires="str,menhirLib,visitors.ppx,visitors.runtime,ppx_deriving_yojson,yojson"
-archive(byte)="morbig.cma"
-archive(native)="morbig.cmxa"
-archive(native,plugin)="morbig.cmxs"


### PR DESCRIPTION
`META` dates from Morbig 0.9
`.merlin` is the old fashioned way to do things