### PR TITLE
Cancel running CI on new push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,13 @@ on:
       - '*'
   pull_request:
 
+## We specify a concurrency group with automated cancellation. This means that
+## other pushes on the same `github.ref` (eg. other pushes to the same pull
+## request) cancel previous occurrences of the CI.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   ## ========================= [ OPAM-based CI ] ========================= ##

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+
 jobs:
 
   ## ========================= [ OPAM-based CI ] ========================= ##

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-
 jobs:
 
   ## ========================= [ OPAM-based CI ] ========================= ##


### PR DESCRIPTION
This PR tweaks the CI so that new pushes cancel previously-running CI. This is particularly important for Morbig that has such a heavy CI with 29 (!!) checks. To see how this works, cf:

- comment in the code
- https://docs.github.com/en/actions/using-jobs/using-concurrency