### PR TITLE
Rework handling of assignment words

### DIFF
--- a/src/CST.mli
+++ b/src/CST.mli
@@ -319,7 +319,6 @@ and word_cst = word_component list
 and word_component =
   | WordSubshell of subshell_kind * program located
   | WordName of string
-  | WordAssignmentWord of assignment_word
   | WordDoubleQuoted of word
   | WordSingleQuoted of word
   | WordTildePrefix of string

--- a/src/CSTHelpers.ml
+++ b/src/CSTHelpers.ml
@@ -230,3 +230,17 @@ let io_redirect_list_of_simple_command = function
     io_redirect_list_of_cmd_suffix cmd_suffix'.value
   | SimpleCommand_CmdName _ ->
     []
+
+let merge_leading_literals =
+  let buf = Buffer.create 80 in
+  let rec extract_leading_literals = function
+    | WordLiteral lit :: rest ->
+      Buffer.add_string buf lit;
+      extract_leading_literals rest
+    | rest -> rest
+  in
+  fun word ->
+    let rest = extract_leading_literals word in
+    let lit = Buffer.contents buf in
+    Buffer.reset buf;
+    if lit = "" then word else WordLiteral lit :: rest

--- a/src/CSTHelpers.ml
+++ b/src/CSTHelpers.ml
@@ -139,8 +139,8 @@ let unName (Name s) = s
 
 let word_of_name (Name w) = Word (w, [WordName w])
 
-let word_of_assignment_word (Name n, (Word (s, _) as w)) =
-  Word (n ^ "=" ^ s, [WordAssignmentWord (Name n, w)])
+let word_of_assignment_word (Name name, Word (word_str, word_cst)) =
+  Word (name ^ "=" ^ word_str, WordLiteral (name ^ "=") :: word_cst)
 
 let string_of_word (Word (s, _)) = s
 

--- a/src/CSTHelpers.mli
+++ b/src/CSTHelpers.mli
@@ -71,3 +71,6 @@ val io_redirect_list_of_cmd_prefix : cmd_prefix -> io_redirect' list
 val io_redirect_list_of_cmd_suffix : cmd_suffix -> io_redirect' list
 val io_redirect_list_of_simple_command : simple_command -> io_redirect' list
 val io_redirect_list_of_redirect_list : redirect_list -> io_redirect' list
+
+(** Merges several leading [WordLiteral] into one. *)
+val merge_leading_literals : word_cst -> word_cst

--- a/src/assignment.ml
+++ b/src/assignment.ml
@@ -60,6 +60,9 @@ let recognize_assignment checkpoint pretoken (Word (word_str, word_cst)) =
               else
                 WordLiteral literal_leftover :: word_cst_leftover
             in
+            (* Now that we know we're in an assignment, we know there are
+               potentially more tilde prefixes to recognize. *)
+            let word_cst = TildePrefix.recognize ~in_assignment:true word_cst in
             let word = Word (word_str_leftover, word_cst) in
             let token = ASSIGNMENT_WORD (Name name, word) in
             if accepted_token checkpoint (token, pstart, pstop) <> Wrong then

--- a/src/engine.ml
+++ b/src/engine.ml
@@ -336,7 +336,7 @@ module Lexer (U : sig end) : Lexer = struct
             | _ -> false
         in
         let token = FirstSuccessMonad.(
-            (recognize_assignment checkpoint p cst)
+            (recognize_assignment checkpoint p (Word (w0, cst)))
             +> (recognize_reserved_word_if_relevant
                   well_delimited_keyword checkpoint p w)
             +> return word

--- a/src/prelexerState.ml
+++ b/src/prelexerState.ml
@@ -366,7 +366,9 @@ let return ?(with_newline=false) lexbuf (current : prelexer_state) tokens =
             | QuotingMark _ -> []
           ) (buffer current)))
       in
-      let csts = TildePrefix.recognize ~in_assignment:false csts in (* FIXME: sometimes should be true *)
+      (* At this point, we cannot say whether this will be an assignment word,
+         so we do a minimal tilde prefixes recognition. *)
+      let csts = TildePrefix.recognize ~in_assignment:false csts in
       [Pretoken.PreWord (w, csts)]
   in
   let tokens = if with_newline then tokens @ [Pretoken.NEWLINE] else tokens in

--- a/src/prelexerState.ml
+++ b/src/prelexerState.ml
@@ -188,7 +188,7 @@ let string_of_word (Word (s, _)) = s
 
 let string_of_attribute = function
   | NoAttribute -> ""
-  | ParameterLength -> "#" 
+  | ParameterLength -> "#"
   | UseDefaultValues (p, w) -> p ^ string_of_word w
   | AssignDefaultValues (p, w) -> p ^ string_of_word w
   | IndicateErrorifNullorUnset (p, w) -> p ^ string_of_word w
@@ -366,7 +366,7 @@ let return ?(with_newline=false) lexbuf (current : prelexer_state) tokens =
             | QuotingMark _ -> []
           ) (buffer current)))
       in
-      let csts = TildePrefix.recognize csts in
+      let csts = TildePrefix.recognize ~in_assignment:false csts in (* FIXME: sometimes should be true *)
       [Pretoken.PreWord (w, csts)]
   in
   let tokens = if with_newline then tokens @ [Pretoken.NEWLINE] else tokens in

--- a/src/tildePrefix.ml
+++ b/src/tildePrefix.ml
@@ -121,12 +121,10 @@ let rec concat_words_with_colon (words : word_cst list) : word_cst =
 (** Recognises tilde prefixes in a word, that is recognises eg. [WordLiteral
     "~foo"] and replaces it by [WordTildePrefix "foo"] when in the right
     position. *)
-let recognize (word : word_cst) =
-  match word with
-  | [WordAssignmentWord (name, Word (s, word))] ->
+let recognize ~in_assignment (word : word_cst) =
+  if in_assignment then
     let words = split_word_on_colon word in
     let words = List.map extract_tilde_prefix_from_word_if_present words in
-    let word = concat_words_with_colon words in
-    [WordAssignmentWord (name, Word (s, word))]
-  | _ ->
+    concat_words_with_colon words
+  else
     extract_tilde_prefix_from_word_if_present word

--- a/src/tildePrefix.ml
+++ b/src/tildePrefix.ml
@@ -61,25 +61,10 @@ let extract_tilde_prefix_from_literal (literal : string) : word_cst =
     let (first, rest) = ExtPervasives.string_split i literal in
     [WordTildePrefix (strip_tilde first); WordLiteral rest]
 
-(** Merges several leading [WordLiteral] into one. *)
-let merge_leading_literals : word_cst -> word_cst =
-  let buf = Buffer.create 80 in
-  let rec extract_leading_literals = function
-    | WordLiteral lit :: rest ->
-      Buffer.add_string buf lit;
-      extract_leading_literals rest
-    | rest -> rest
-  in
-  fun word ->
-    let rest = extract_leading_literals word in
-    let lit = Buffer.contents buf in
-    Buffer.reset buf;
-    if lit = "" then word else WordLiteral lit :: rest
-
 (** Extracts the tilde-prefix at the beginning of the given word CST if there is
     one. Otherwise, returns the word as-is. *)
 let extract_tilde_prefix_from_word_if_present (word : word_cst) : word_cst =
-  match merge_leading_literals word with
+  match CSTHelpers.merge_leading_literals word with
   | WordLiteral literal :: word when starts_with_tilde literal ->
     extract_tilde_prefix_from_literal literal @ word
   | word -> word

--- a/tests/golden/good/2.3-token-recognition/2.3.1-alias-substitution/alias-alias.t/expected.json
+++ b/tests/golden/good/2.3-token-recognition/2.3.1-alias-substitution/alias-alias.t/expected.json
@@ -43,23 +43,8 @@
                           "rename=alias",
                           [
                             [
-                              "WordAssignmentWord",
-                              [
-                                [
-                                  "Name",
-                                  "rename"
-                                ],
-                                [
-                                  "Word",
-                                  "alias",
-                                  [
-                                    [
-                                      "WordLiteral",
-                                      "alias"
-                                    ]
-                                  ]
-                                ]
-                              ]
+                              "WordLiteral",
+                              "rename=alias"
                             ]
                           ]
                         ]
@@ -109,23 +94,8 @@
                         "time=date",
                         [
                           [
-                            "WordAssignmentWord",
-                            [
-                              [
-                                "Name",
-                                "time"
-                              ],
-                              [
-                                "Word",
-                                "date",
-                                [
-                                  [
-                                    "WordLiteral",
-                                    "date"
-                                  ]
-                                ]
-                              ]
-                            ]
+                            "WordLiteral",
+                            "time=date"
                           ]
                         ]
                       ]

--- a/tests/golden/good/2.3-token-recognition/2.3.1-alias-substitution/alias-commands-words-only.t/expected.json
+++ b/tests/golden/good/2.3-token-recognition/2.3.1-alias-substitution/alias-commands-words-only.t/expected.json
@@ -41,23 +41,8 @@
                         "show=echo",
                         [
                           [
-                            "WordAssignmentWord",
-                            [
-                              [
-                                "Name",
-                                "show"
-                              ],
-                              [
-                                "Word",
-                                "echo",
-                                [
-                                  [
-                                    "WordLiteral",
-                                    "echo"
-                                  ]
-                                ]
-                              ]
-                            ]
+                            "WordLiteral",
+                            "show=echo"
                           ]
                         ]
                       ]

--- a/tests/golden/good/2.3-token-recognition/2.3.1-alias-substitution/alias-cycle.t/expected.json
+++ b/tests/golden/good/2.3-token-recognition/2.3.1-alias-substitution/alias-cycle.t/expected.json
@@ -41,29 +41,18 @@
                         "ls='ls -h -t -l'",
                         [
                           [
-                            "WordAssignmentWord",
+                            "WordLiteral",
+                            "ls="
+                          ],
+                          [
+                            "WordSingleQuoted",
                             [
+                              "Word",
+                              "ls -h -t -l",
                               [
-                                "Name",
-                                "ls"
-                              ],
-                              [
-                                "Word",
-                                "'ls -h -t -l'",
                                 [
-                                  [
-                                    "WordSingleQuoted",
-                                    [
-                                      "Word",
-                                      "ls -h -t -l",
-                                      [
-                                        [
-                                          "WordLiteral",
-                                          "ls -h -t -l"
-                                        ]
-                                      ]
-                                    ]
-                                  ]
+                                  "WordLiteral",
+                                  "ls -h -t -l"
                                 ]
                               ]
                             ]

--- a/tests/golden/good/2.3-token-recognition/2.3.1-alias-substitution/alias-mixed-arguments.t/expected.json
+++ b/tests/golden/good/2.3-token-recognition/2.3.1-alias-substitution/alias-mixed-arguments.t/expected.json
@@ -45,23 +45,8 @@
                             "titi=TITI",
                             [
                               [
-                                "WordAssignmentWord",
-                                [
-                                  [
-                                    "Name",
-                                    "titi"
-                                  ],
-                                  [
-                                    "Word",
-                                    "TITI",
-                                    [
-                                      [
-                                        "WordLiteral",
-                                        "TITI"
-                                      ]
-                                    ]
-                                  ]
-                                ]
+                                "WordLiteral",
+                                "titi=TITI"
                               ]
                             ]
                           ]
@@ -71,23 +56,8 @@
                           "toto=TOTO",
                           [
                             [
-                              "WordAssignmentWord",
-                              [
-                                [
-                                  "Name",
-                                  "toto"
-                                ],
-                                [
-                                  "Word",
-                                  "TOTO",
-                                  [
-                                    [
-                                      "WordLiteral",
-                                      "TOTO"
-                                    ]
-                                  ]
-                                ]
-                              ]
+                              "WordLiteral",
+                              "toto=TOTO"
                             ]
                           ]
                         ]
@@ -143,23 +113,8 @@
                               "tata=TATA",
                               [
                                 [
-                                  "WordAssignmentWord",
-                                  [
-                                    [
-                                      "Name",
-                                      "tata"
-                                    ],
-                                    [
-                                      "Word",
-                                      "TATA",
-                                      [
-                                        [
-                                          "WordLiteral",
-                                          "TATA"
-                                        ]
-                                      ]
-                                    ]
-                                  ]
+                                  "WordLiteral",
+                                  "tata=TATA"
                                 ]
                               ]
                             ]
@@ -180,23 +135,8 @@
                           "tutu=TUTU",
                           [
                             [
-                              "WordAssignmentWord",
-                              [
-                                [
-                                  "Name",
-                                  "tutu"
-                                ],
-                                [
-                                  "Word",
-                                  "TUTU",
-                                  [
-                                    [
-                                      "WordLiteral",
-                                      "TUTU"
-                                    ]
-                                  ]
-                                ]
-                              ]
+                              "WordLiteral",
+                              "tutu=TUTU"
                             ]
                           ]
                         ]

--- a/tests/golden/good/2.3-token-recognition/2.3.1-alias-substitution/alias-multiple-arguments.t/expected.json
+++ b/tests/golden/good/2.3-token-recognition/2.3.1-alias-substitution/alias-multiple-arguments.t/expected.json
@@ -47,23 +47,8 @@
                               "show=echo",
                               [
                                 [
-                                  "WordAssignmentWord",
-                                  [
-                                    [
-                                      "Name",
-                                      "show"
-                                    ],
-                                    [
-                                      "Word",
-                                      "echo",
-                                      [
-                                        [
-                                          "WordLiteral",
-                                          "echo"
-                                        ]
-                                      ]
-                                    ]
-                                  ]
+                                  "WordLiteral",
+                                  "show=echo"
                                 ]
                               ]
                             ]
@@ -73,23 +58,8 @@
                             "list=ls",
                             [
                               [
-                                "WordAssignmentWord",
-                                [
-                                  [
-                                    "Name",
-                                    "list"
-                                  ],
-                                  [
-                                    "Word",
-                                    "ls",
-                                    [
-                                      [
-                                        "WordLiteral",
-                                        "ls"
-                                      ]
-                                    ]
-                                  ]
-                                ]
+                                "WordLiteral",
+                                "list=ls"
                               ]
                             ]
                           ]
@@ -99,23 +69,8 @@
                           "coocoo=kiki",
                           [
                             [
-                              "WordAssignmentWord",
-                              [
-                                [
-                                  "Name",
-                                  "coocoo"
-                                ],
-                                [
-                                  "Word",
-                                  "kiki",
-                                  [
-                                    [
-                                      "WordLiteral",
-                                      "kiki"
-                                    ]
-                                  ]
-                                ]
-                              ]
+                              "WordLiteral",
+                              "coocoo=kiki"
                             ]
                           ]
                         ]

--- a/tests/golden/good/2.3-token-recognition/2.3.1-alias-substitution/alias-with-final-whitespace.t/expected.json
+++ b/tests/golden/good/2.3-token-recognition/2.3.1-alias-substitution/alias-with-final-whitespace.t/expected.json
@@ -51,29 +51,18 @@
                                   "x='echo '",
                                   [
                                     [
-                                      "WordAssignmentWord",
+                                      "WordLiteral",
+                                      "x="
+                                    ],
+                                    [
+                                      "WordSingleQuoted",
                                       [
+                                        "Word",
+                                        "echo ",
                                         [
-                                          "Name",
-                                          "x"
-                                        ],
-                                        [
-                                          "Word",
-                                          "'echo '",
                                           [
-                                            [
-                                              "WordSingleQuoted",
-                                              [
-                                                "Word",
-                                                "echo ",
-                                                [
-                                                  [
-                                                    "WordLiteral",
-                                                    "echo "
-                                                  ]
-                                                ]
-                                              ]
-                                            ]
+                                            "WordLiteral",
+                                            "echo "
                                           ]
                                         ]
                                       ]
@@ -126,29 +115,18 @@
                                 "z='a '",
                                 [
                                   [
-                                    "WordAssignmentWord",
+                                    "WordLiteral",
+                                    "z="
+                                  ],
+                                  [
+                                    "WordSingleQuoted",
                                     [
+                                      "Word",
+                                      "a ",
                                       [
-                                        "Name",
-                                        "z"
-                                      ],
-                                      [
-                                        "Word",
-                                        "'a '",
                                         [
-                                          [
-                                            "WordSingleQuoted",
-                                            [
-                                              "Word",
-                                              "a ",
-                                              [
-                                                [
-                                                  "WordLiteral",
-                                                  "a "
-                                                ]
-                                              ]
-                                            ]
-                                          ]
+                                          "WordLiteral",
+                                          "a "
                                         ]
                                       ]
                                     ]

--- a/tests/golden/good/2.3-token-recognition/2.3.1-alias-substitution/toplevel-alias.t/expected.json
+++ b/tests/golden/good/2.3-token-recognition/2.3.1-alias-substitution/toplevel-alias.t/expected.json
@@ -41,23 +41,8 @@
                         "foo=for",
                         [
                           [
-                            "WordAssignmentWord",
-                            [
-                              [
-                                "Name",
-                                "foo"
-                              ],
-                              [
-                                "Word",
-                                "for",
-                                [
-                                  [
-                                    "WordLiteral",
-                                    "for"
-                                  ]
-                                ]
-                              ]
-                            ]
+                            "WordLiteral",
+                            "foo=for"
                           ]
                         ]
                       ]

--- a/tests/golden/good/2.3-token-recognition/2.3.1-alias-substitution/toplevel-unalias.t/expected.json
+++ b/tests/golden/good/2.3-token-recognition/2.3.1-alias-substitution/toplevel-unalias.t/expected.json
@@ -45,29 +45,18 @@
                             "foo='ls -l'",
                             [
                               [
-                                "WordAssignmentWord",
+                                "WordLiteral",
+                                "foo="
+                              ],
+                              [
+                                "WordSingleQuoted",
                                 [
+                                  "Word",
+                                  "ls -l",
                                   [
-                                    "Name",
-                                    "foo"
-                                  ],
-                                  [
-                                    "Word",
-                                    "'ls -l'",
                                     [
-                                      [
-                                        "WordSingleQuoted",
-                                        [
-                                          "Word",
-                                          "ls -l",
-                                          [
-                                            [
-                                              "WordLiteral",
-                                              "ls -l"
-                                            ]
-                                          ]
-                                        ]
-                                      ]
+                                      "WordLiteral",
+                                      "ls -l"
                                     ]
                                   ]
                                 ]

--- a/tests/golden/good/2.3-token-recognition/2.3.1-alias-substitution/unalias-a.t/expected.json
+++ b/tests/golden/good/2.3-token-recognition/2.3.1-alias-substitution/unalias-a.t/expected.json
@@ -47,23 +47,8 @@
                               "tata=TATA",
                               [
                                 [
-                                  "WordAssignmentWord",
-                                  [
-                                    [
-                                      "Name",
-                                      "tata"
-                                    ],
-                                    [
-                                      "Word",
-                                      "TATA",
-                                      [
-                                        [
-                                          "WordLiteral",
-                                          "TATA"
-                                        ]
-                                      ]
-                                    ]
-                                  ]
+                                  "WordLiteral",
+                                  "tata=TATA"
                                 ]
                               ]
                             ]
@@ -73,23 +58,8 @@
                             "titi=TITI",
                             [
                               [
-                                "WordAssignmentWord",
-                                [
-                                  [
-                                    "Name",
-                                    "titi"
-                                  ],
-                                  [
-                                    "Word",
-                                    "TITI",
-                                    [
-                                      [
-                                        "WordLiteral",
-                                        "TITI"
-                                      ]
-                                    ]
-                                  ]
-                                ]
+                                "WordLiteral",
+                                "titi=TITI"
                               ]
                             ]
                           ]

--- a/tests/golden/good/2.3-token-recognition/2.3.1-alias-substitution/unalias-multiple-arguments.t/expected.json
+++ b/tests/golden/good/2.3-token-recognition/2.3.1-alias-substitution/unalias-multiple-arguments.t/expected.json
@@ -45,23 +45,8 @@
                             "show=echo",
                             [
                               [
-                                "WordAssignmentWord",
-                                [
-                                  [
-                                    "Name",
-                                    "show"
-                                  ],
-                                  [
-                                    "Word",
-                                    "echo",
-                                    [
-                                      [
-                                        "WordLiteral",
-                                        "echo"
-                                      ]
-                                    ]
-                                  ]
-                                ]
+                                "WordLiteral",
+                                "show=echo"
                               ]
                             ]
                           ]
@@ -111,23 +96,8 @@
                           "list=ls",
                           [
                             [
-                              "WordAssignmentWord",
-                              [
-                                [
-                                  "Name",
-                                  "list"
-                                ],
-                                [
-                                  "Word",
-                                  "ls",
-                                  [
-                                    [
-                                      "WordLiteral",
-                                      "ls"
-                                    ]
-                                  ]
-                                ]
-                              ]
+                              "WordLiteral",
+                              "list=ls"
                             ]
                           ]
                         ]

--- a/tests/golden/good/2.6-word-expansions/2.6.1-tilde-prefix/login.t/expected.json
+++ b/tests/golden/good/2.6-word-expansions/2.6.1-tilde-prefix/login.t/expected.json
@@ -537,27 +537,8 @@
                             "W=~knuth/foo/bar",
                             [
                               [
-                                "WordAssignmentWord",
-                                [
-                                  [
-                                    "Name",
-                                    "W"
-                                  ],
-                                  [
-                                    "Word",
-                                    "~knuth/foo/bar",
-                                    [
-                                      [
-                                        "WordTildePrefix",
-                                        "knuth"
-                                      ],
-                                      [
-                                        "WordLiteral",
-                                        "/foo/bar"
-                                      ]
-                                    ]
-                                  ]
-                                ]
+                                "WordLiteral",
+                                "W=~knuth/foo/bar"
                               ]
                             ]
                           ]
@@ -607,47 +588,8 @@
                           "X=~kn:~/bin:~darkvador/secret",
                           [
                             [
-                              "WordAssignmentWord",
-                              [
-                                [
-                                  "Name",
-                                  "X"
-                                ],
-                                [
-                                  "Word",
-                                  "~kn:~/bin:~darkvador/secret",
-                                  [
-                                    [
-                                      "WordTildePrefix",
-                                      "kn"
-                                    ],
-                                    [
-                                      "WordLiteral",
-                                      ":"
-                                    ],
-                                    [
-                                      "WordTildePrefix",
-                                      ""
-                                    ],
-                                    [
-                                      "WordLiteral",
-                                      "/bin"
-                                    ],
-                                    [
-                                      "WordLiteral",
-                                      ":"
-                                    ],
-                                    [
-                                      "WordTildePrefix",
-                                      "darkvador"
-                                    ],
-                                    [
-                                      "WordLiteral",
-                                      "/secret"
-                                    ]
-                                  ]
-                                ]
-                              ]
+                              "WordLiteral",
+                              "X=~kn:~/bin:~darkvador/secret"
                             ]
                           ]
                         ]
@@ -697,51 +639,8 @@
                         "Y=~kn:/bonjour:~/bonsoir:and/this/one",
                         [
                           [
-                            "WordAssignmentWord",
-                            [
-                              [
-                                "Name",
-                                "Y"
-                              ],
-                              [
-                                "Word",
-                                "~kn:/bonjour:~/bonsoir:and/this/one",
-                                [
-                                  [
-                                    "WordTildePrefix",
-                                    "kn"
-                                  ],
-                                  [
-                                    "WordLiteral",
-                                    ":"
-                                  ],
-                                  [
-                                    "WordLiteral",
-                                    "/bonjour"
-                                  ],
-                                  [
-                                    "WordLiteral",
-                                    ":"
-                                  ],
-                                  [
-                                    "WordTildePrefix",
-                                    ""
-                                  ],
-                                  [
-                                    "WordLiteral",
-                                    "/bonsoir"
-                                  ],
-                                  [
-                                    "WordLiteral",
-                                    ":"
-                                  ],
-                                  [
-                                    "WordLiteral",
-                                    "and/this/one"
-                                  ]
-                                ]
-                              ]
-                            ]
+                            "WordLiteral",
+                            "Y=~kn:/bonjour:~/bonsoir:and/this/one"
                           ]
                         ]
                       ]
@@ -791,51 +690,8 @@
                       "Z=/bonjour:~kn:~/bonsoir:and/this/one",
                       [
                         [
-                          "WordAssignmentWord",
-                          [
-                            [
-                              "Name",
-                              "Z"
-                            ],
-                            [
-                              "Word",
-                              "/bonjour:~kn:~/bonsoir:and/this/one",
-                              [
-                                [
-                                  "WordLiteral",
-                                  "/bonjour"
-                                ],
-                                [
-                                  "WordLiteral",
-                                  ":"
-                                ],
-                                [
-                                  "WordTildePrefix",
-                                  "kn"
-                                ],
-                                [
-                                  "WordLiteral",
-                                  ":"
-                                ],
-                                [
-                                  "WordTildePrefix",
-                                  ""
-                                ],
-                                [
-                                  "WordLiteral",
-                                  "/bonsoir"
-                                ],
-                                [
-                                  "WordLiteral",
-                                  ":"
-                                ],
-                                [
-                                  "WordLiteral",
-                                  "and/this/one"
-                                ]
-                              ]
-                            ]
-                          ]
+                          "WordLiteral",
+                          "Z=/bonjour:~kn:~/bonsoir:and/this/one"
                         ]
                       ]
                     ]

--- a/tests/golden/good/2.9-shell-commands/2.9.1-simple-commands/assignment-words.t/expected.json
+++ b/tests/golden/good/2.9-shell-commands/2.9.1-simple-commands/assignment-words.t/expected.json
@@ -102,23 +102,8 @@
                           "CC=cc",
                           [
                             [
-                              "WordAssignmentWord",
-                              [
-                                [
-                                  "Name",
-                                  "CC"
-                                ],
-                                [
-                                  "Word",
-                                  "cc",
-                                  [
-                                    [
-                                      "WordLiteral",
-                                      "cc"
-                                    ]
-                                  ]
-                                ]
-                              ]
+                              "WordLiteral",
+                              "CC=cc"
                             ]
                           ]
                         ]

--- a/tests/golden/good/2.9-shell-commands/2.9.4-compound-commands/for/for-assignment-in-wordlist.t/expected.json
+++ b/tests/golden/good/2.9-shell-commands/2.9.4-compound-commands/for/for-assignment-in-wordlist.t/expected.json
@@ -35,23 +35,8 @@
                         "BOOT_START=start_on_boot",
                         [
                           [
-                            "WordAssignmentWord",
-                            [
-                              [
-                                "Name",
-                                "BOOT_START"
-                              ],
-                              [
-                                "Word",
-                                "start_on_boot",
-                                [
-                                  [
-                                    "WordLiteral",
-                                    "start_on_boot"
-                                  ]
-                                ]
-                              ]
-                            ]
+                            "WordLiteral",
+                            "BOOT_START=start_on_boot"
                           ]
                         ]
                       ]

--- a/tests/golden/good/assignment-empty.t/expected.json
+++ b/tests/golden/good/assignment-empty.t/expected.json
@@ -18,17 +18,18 @@
               [
                 "Command_SimpleCommand",
                 [
-                  "SimpleCommand_CmdName",
+                  "SimpleCommand_CmdPrefix",
                   [
-                    "CmdName_Word",
+                    "CmdPrefix_AssignmentWord",
                     [
-                      "Word",
-                      "A=",
                       [
-                        [
-                          "WordLiteral",
-                          "A="
-                        ]
+                        "Name",
+                        "A"
+                      ],
+                      [
+                        "Word",
+                        "",
+                        []
                       ]
                     ]
                   ]

--- a/tests/golden/good/assignment-eof.t/expected.json
+++ b/tests/golden/good/assignment-eof.t/expected.json
@@ -39,23 +39,8 @@
                       "b=c",
                       [
                         [
-                          "WordAssignmentWord",
-                          [
-                            [
-                              "Name",
-                              "b"
-                            ],
-                            [
-                              "Word",
-                              "c",
-                              [
-                                [
-                                  "WordLiteral",
-                                  "c"
-                                ]
-                              ]
-                            ]
-                          ]
+                          "WordLiteral",
+                          "b=c"
                         ]
                       ]
                     ]


### PR DESCRIPTION
This pull request reworks the way assignment words are handled in Morbig. It is to be noted that Morbig was correctly promoting parsing tokens from WORD to ASSIGNMENT_WORD and thus yielding reasonable CSTs. What this PR fixes is only the processing of assignment words in word CSTs only.

The most important change is the disappearance of the `WordAssignmentWord` in `word_cst`. I think this constructor made very little sense in itself because assignment words were already handled in the CST as `CmdPrefix_AssignmentWord` constructors carrying a name and a word. There were probably two reasons why this word CST constructor existed:

1. Because it might be practical for client libraries (eg. static analysers) to already have access to assignment words in other places (eg. as arguments of `alias` or `make`). I think this is a bad argument: in the semantics of Shell, those words are not assignment words, it is only the utilities that decide to see them as such, and they should do so in the way that is practical for them. We can offer a helper to do that nicely in word CSTs.

2. As an intermediary state to store words that could be assignment words before reaching the proper assignment words recognition. I think that makes sense but (a) it clutters the output type with an extra useless constructor, (b) Morbig actually leaves quite a lot of those in its output, and (c) it breaks tilde prefixes recognition that was based on the presence of such constructors.

I think it is better to get rid of it altogether. This PR therefore removes the `WordAssignmentWord` constructor of `word_cst`, rewrites `Assignment.recognize_assignment` to not rely on it, and gets rid of `PrelexerState.recognize_assignment` as well.

Additionally, I took this opportunity to fix the tilde prefixes recognition mechanism. The main problem was that tilde prefixes recognition changes depending on whether we are in an assignment word, in which case it splits the word on colon characters and recognises tilde prefixes in all the components. This was being overzealous. This recognition is now made in two steps: during prelexing, only standard tilde prefixes (at the beginning of words) are recognised. During parsing, when yielding a `CmdPrefix_AssignmentWords`, tilde prefixes are recognised again, this time fully.

I updated the expectation files and checked them one by one. I am happy with the result. A lot of them actually have to do with tests on alias and are not very interesting when it comes to parsing assignment words. There are two main interesting test files:

- `good/2.6-word-expansions/2.6.1-tilde-prefix/login.t` is the one discussed in https://github.com/colis-anr/morbig/pull/164#issuecomment-1539311366 which led to writing https://github.com/colis-anr/morbig/issues/165. After this change, the last lines:
  ```
  echo W=~knuth/foo/bar
  echo X=~kn:~/bin:~darkvador/secret
  echo Y=~kn:/bonjour:~/bonsoir:and/this/one
  echo Z=/bonjour:~kn:~/bonsoir:and/this/one
  ```
  are correctly handled as containing no tilde prefixes.

- `tests/golden/good/2.9-shell-commands/2.9.1-simple-commands/assignment-words.t/input.sh`, funnily enough, explains the subtelty handled in this PR:
  ```
  CC=gcc make
  make CC=cc
  ln -s /bin/ls "X=1"
  "./X"=1 echo
  
  # On line 1, the word CC=gcc is recognized as a word assignment of gcc
  # to CC because CC is a valid name for a variable, and because CC=gcc
  # is written just before the command name of the simple command
  # make. On line 2, the word CC=cc is not promoted to a word assignment
  # because it appears after the command name of a simple command. On
  # line 4, since "./X" is not a valid name for a shell variable, the
  # word "./X=1" is not promoted to a word assignment and is interpreted
  # as the command name of a simple command.
  ```
  However, Morbig, until now, was precisely recognising `CC=cc` as an assignment words. Not anymore.

@yurug WDYT?