### PR TITLE
Update Nix configuration

### DIFF
--- a/.nix/with-nixpkgs.nix
+++ b/.nix/with-nixpkgs.nix
@@ -39,6 +39,9 @@
         installPhase = ''
           make install PREFIX=$out LIBDIR=$OCAMLFIND_DESTDIR
         '';
+
+        meta.description =
+          "Morbig, where all the dependencies come from `nixpkgs`.";
       };
     };
 }

--- a/.nix/with-opam-nix.nix
+++ b/.nix/with-opam-nix.nix
@@ -8,5 +8,11 @@
         resolveArgs.with-doc = true;
         resolveArgs.with-test = true;
       } "morbig" ./.. { ocaml-base-compiler = "*"; };
-    in { packages.with-opam-nix = scope.morbig // { inherit scope; }; };
+    in {
+      packages.with-opam-nix = scope.morbig // {
+        inherit scope;
+        meta.description =
+          "Morbig, where all the dependencies are handled by `opam-nix`.";
+      };
+    };
 }

--- a/flake.lock
+++ b/flake.lock
@@ -37,11 +37,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1680392223,
-        "narHash": "sha256-n3g7QFr85lDODKt250rkZj2IFS3i4/8HBU2yKHO3tqw=",
+        "lastModified": 1685662779,
+        "narHash": "sha256-cKDDciXGpMEjP1n6HlzKinN0H+oLmNpgeCTzYnsA2po=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "dcc36e45d054d7bb554c9cdab69093debd91a0b5",
+        "rev": "71fb97f0d875fd4de4994dfb849f2c75e17eb6c3",
         "type": "github"
       },
       "original": {
@@ -66,12 +66,15 @@
       }
     },
     "flake-utils_2": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1667395993,
-        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "lastModified": 1685518550,
+        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
         "type": "github"
       },
       "original": {
@@ -119,11 +122,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1681737997,
-        "narHash": "sha256-pHhjgsIkRMu80LmVe8QoKIZB6VZGRRxFmIvsC5S89k4=",
+        "lastModified": 1686960236,
+        "narHash": "sha256-AYCC9rXNLpUWzD9hm+askOfpliLEC9kwAo7ITJc4HIw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "f00994e78cd39e6fc966f0c4103f908e63284780",
+        "rev": "04af42f3b31dba0ef742d254456dc4c14eedac86",
         "type": "github"
       },
       "original": {
@@ -136,11 +139,11 @@
     "nixpkgs-lib": {
       "locked": {
         "dir": "lib",
-        "lastModified": 1680213900,
-        "narHash": "sha256-cIDr5WZIj3EkKyCgj/6j3HBH4Jj1W296z7HTcWj1aMA=",
+        "lastModified": 1685564631,
+        "narHash": "sha256-8ywr3AkblY4++3lIVxmrWZFzac7+f32ZEhH/A8pNscI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e3652e0735fbec227f342712f180f4f21f0594f2",
+        "rev": "4f53efe34b3a8877ac923b9350c874e3dcd5dc0a",
         "type": "github"
       },
       "original": {
@@ -164,11 +167,11 @@
         "opam2json": "opam2json"
       },
       "locked": {
-        "lastModified": 1682411044,
-        "narHash": "sha256-HJY+LANQ75YQSfaTCOnmtiF4pF8d9Eb4dz+wLyNAihE=",
+        "lastModified": 1686742877,
+        "narHash": "sha256-HOWgC19NkL4+7DCbXgocRE9MZUxT5lhBWv3YF5z7LL8=",
         "owner": "tweag",
         "repo": "opam-nix",
-        "rev": "02f7ae28a210e17ca5811b0a4c116acd94e82faa",
+        "rev": "06bd670789748155195083ddabd8a383bac4cc5c",
         "type": "github"
       },
       "original": {
@@ -241,11 +244,11 @@
         "nixpkgs-stable": []
       },
       "locked": {
-        "lastModified": 1682596858,
-        "narHash": "sha256-Hf9XVpqaGqe/4oDGr30W8HlsWvJXtMsEPHDqHZA6dDg=",
+        "lastModified": 1687251716,
+        "narHash": "sha256-+sFS41thsB5U+lY/dBYPSmU4AJ7nz/VdM1WD35fXVeM=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "fb58866e20af98779017134319b5663b8215d912",
+        "rev": "7807e1851d95828ed98491930d2d9e7ddbe65da4",
         "type": "github"
       },
       "original": {
@@ -260,6 +263,21 @@
         "nixpkgs": "nixpkgs",
         "opam-nix": "opam-nix",
         "pre-commit-hooks": "pre-commit-hooks"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.lock
+++ b/flake.lock
@@ -151,22 +151,6 @@
         "type": "github"
       }
     },
-    "nixpkgs-stable": {
-      "locked": {
-        "lastModified": 1678872516,
-        "narHash": "sha256-/E1YwtMtFAu2KUQKV/1+KFuReYPANM2Rzehk84VxVoc=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "9b8e5abb18324c7fe9f07cb100c3cd4a29cda8b8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-22.11",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "opam-nix": {
       "inputs": {
         "flake-compat": "flake-compat",
@@ -254,7 +238,7 @@
         "nixpkgs": [
           "nixpkgs"
         ],
-        "nixpkgs-stable": "nixpkgs-stable"
+        "nixpkgs-stable": []
       },
       "locked": {
         "lastModified": 1682596858,

--- a/flake.nix
+++ b/flake.nix
@@ -10,6 +10,7 @@
     pre-commit-hooks = {
       url = "github:cachix/pre-commit-hooks.nix";
       inputs.nixpkgs.follows = "nixpkgs";
+      inputs.nixpkgs-stable.follows = "";
     };
 
     flake-parts.url = "github:hercules-ci/flake-parts";

--- a/flake.nix
+++ b/flake.nix
@@ -29,7 +29,9 @@
       perSystem = { self', pkgs, config, ... }: {
         formatter = pkgs.nixfmt;
 
-        packages.default = self'.packages.with-nixpkgs;
+        packages.default = self'.packages.with-nixpkgs // {
+          meta.description = "Alias for `with-nixpkgs`.";
+        };
 
         ## For each package, we define a corresponding devShell using its inputs
         ## and adding pre-commit hooks and development tools on top.

--- a/flake.nix
+++ b/flake.nix
@@ -44,25 +44,7 @@
           ocp-indent.enable = true;
           nixfmt.enable = true;
           deadnix.enable = true;
-
-          ## NOTE: The version of the `dune-fmt` hook in `pre-commit-hooks.nix`
-          ## forgets to bring OCaml in the environment. In the meantime, we use
-          ## our own; will change back to `dune-fmt.enable = true` later.
-          tmp-dune-fmt = {
-            enable = true;
-            name = "dune-fmt";
-            description = "Runs Dune's formatters on the code tree.";
-            entry = let
-              dune-fmt = pkgs.writeShellApplication {
-                name = "dune-fmt";
-                text = ''
-                  export PATH=${pkgs.ocaml}/bin:$PATH
-                  exec ${pkgs.dune_3}/bin/dune fmt "$@"
-                '';
-              };
-            in "${dune-fmt}/bin/dune-fmt";
-            pass_filenames = false;
-          };
+          dune-fmt.enable = true;
         };
       };
 

--- a/flake.nix
+++ b/flake.nix
@@ -2,11 +2,15 @@
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
 
-    opam-nix.url = "github:tweag/opam-nix";
-    opam-nix.inputs.nixpkgs.follows = "nixpkgs";
+    opam-nix = {
+      url = "github:tweag/opam-nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
 
-    pre-commit-hooks.url = "github:cachix/pre-commit-hooks.nix";
-    pre-commit-hooks.inputs.nixpkgs.follows = "nixpkgs";
+    pre-commit-hooks = {
+      url = "github:cachix/pre-commit-hooks.nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
 
     flake-parts.url = "github:hercules-ci/flake-parts";
   };

--- a/flake.nix
+++ b/flake.nix
@@ -32,11 +32,8 @@
         packages.default = self'.packages.with-nixpkgs;
 
         devShells.default = pkgs.mkShell {
-          buildInputs = with pkgs.ocamlPackages; [
-            ocaml-lsp
-            ocp-indent
-            headache
-          ];
+          buildInputs = (with pkgs; [ headache ])
+            ++ (with pkgs.ocamlPackages; [ ocaml-lsp ocp-indent ]);
           inputsFrom = [ self'.packages.default ];
           shellHook = config.pre-commit.installationScript;
         };

--- a/flake.nix
+++ b/flake.nix
@@ -31,12 +31,15 @@
 
         packages.default = self'.packages.with-nixpkgs;
 
-        devShells.default = pkgs.mkShell {
-          buildInputs = (with pkgs; [ headache ])
-            ++ (with pkgs.ocamlPackages; [ ocaml-lsp ocp-indent ]);
-          inputsFrom = [ self'.packages.default ];
-          shellHook = config.pre-commit.installationScript;
-        };
+        ## For each package, we define a corresponding devShell using its inputs
+        ## and adding pre-commit hooks and development tools on top.
+        devShells = builtins.mapAttrs (_: package:
+          pkgs.mkShell {
+            buildInputs = (with pkgs; [ headache ])
+              ++ (with pkgs.ocamlPackages; [ ocaml-lsp ocp-indent ]);
+            inputsFrom = [ package ];
+            shellHook = config.pre-commit.installationScript;
+          }) self'.packages;
 
         pre-commit.settings.hooks = {
           dune-opam-sync.enable = true;


### PR DESCRIPTION
- Update Nix flake dependencies and ignore unused inputs.
- Use newly added fixed `dune-fmt` hook (fixed by https://github.com/cachix/pre-commit-hooks.nix/pull/296).
- Have one devShell per package, for people who'd want their development environment handled by `opam-nix` as well.
- Add descriptions to each package in the flake, such that `nix search .` returns slightly useful information.