### PR TITLE
Add Cachix substituter fed by CI

### DIFF
--- a/.github/composites/setup-nix/action.yml
+++ b/.github/composites/setup-nix/action.yml
@@ -1,0 +1,27 @@
+---
+inputs:
+  githubAccessToken:
+    required: true
+  cachixAuthToken:
+    required: true
+
+runs:
+  using: composite
+
+  steps:
+    - name: Install Nix
+      uses: cachix/install-nix-action@v22
+      with:
+        extra_nix_config: |
+          ## Access token to avoid triggering GitHub's rate limiting.
+          access-tokens = github.com=${{ inputs.githubAccessToken }}
+          ## Accept arbitrary substituters from the flake.
+          accept-flake-config = true
+
+    - name: Setup Nix caches
+      uses: cachix/cachix-action@v12
+      with:
+        name: scd-niols-fr
+        ## This auth token will give write access to the cache, meaning that
+        ## everything that happens in CI will be pushed at the end of the job.
+        authToken: "${{ inputs.cachixAuthToken }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -298,12 +298,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Install Nix
-        uses: cachix/install-nix-action@v22
+      - name: Setup Nix
+        uses: ./.github/composites/setup-nix
         with:
-          extra_nix_config: |
-            ## Access token to avoid triggering GitHub's rate limiting.
-            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+          githubAccessToken: ${{ secrets.GITHUB_TOKEN }}
+          cachixAuthToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
       - name: Install Nix dependencies
         run: |
@@ -332,12 +331,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Install Nix
-        uses: cachix/install-nix-action@v22
+      - name: Setup Nix
+        uses: ./.github/composites/setup-nix
         with:
-          extra_nix_config: |
-            ## Access token to avoid triggering GitHub's rate limiting.
-            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+          githubAccessToken: ${{ secrets.GITHUB_TOKEN }}
+          cachixAuthToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
       - name: Run flake checks
         run: nix flake check . --print-build-logs

--- a/flake.nix
+++ b/flake.nix
@@ -69,4 +69,13 @@
       perInput = system: flake:
         if flake ? lib.${system} then { lib = flake.lib.${system}; } else { };
     };
+
+  nixConfig = {
+    extra-trusted-substituters = [
+      "https://morbig.cachix.org/"
+    ];
+    extra-trusted-public-keys = [
+      "morbig.cachix.org-1:l6jrpCfkt03SwhxnK7VNDgrnMDW9OA92BTcuZTNw60I="
+    ];
+  };
 }


### PR DESCRIPTION
The failures do not have to do with our CI but only with `odoc`. One can hope that it gets fixed with time.