### PR TITLE
Improve Nix in CI

### DIFF
--- a/.github/composites/setup-nix/action.yml
+++ b/.github/composites/setup-nix/action.yml
@@ -21,7 +21,7 @@ runs:
     - name: Setup Nix caches
       uses: cachix/cachix-action@v12
       with:
-        name: scd-niols-fr
+        name: morbig
         ## This auth token will give write access to the cache, meaning that
         ## everything that happens in CI will be pushed at the end of the job.
         authToken: "${{ inputs.cachixAuthToken }}"

--- a/.github/composites/setup-nix/action.yml
+++ b/.github/composites/setup-nix/action.yml
@@ -10,7 +10,7 @@ runs:
 
   steps:
     - name: Install Nix
-      uses: cachix/install-nix-action@v22
+      uses: cachix/install-nix-action@v23
       with:
         extra_nix_config: |
           ## Access token to avoid triggering GitHub's rate limiting.


### PR DESCRIPTION
Fix Cachix instance: we push to `morbig`, not `scd-niols-fr` (to which we do not have access anyways)
Also bump the version of `install-nix-action` from 22 to 23.