### PR TITLE
Support current Menhir and Yojson releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,14 +83,6 @@ jobs:
       - name: Install Dune
         run: opam install dune --yes
 
-      # Remove these temporary pins once the current Menhir and Yojson
-      # compatibility changes have landed.
-      - name: Pin compatible dependency versions
-        if: matrix.lower-bounds != 'lower-bounds'
-        run: |
-          opam pin add --no-action menhir 20240715
-          opam pin add --no-action yojson 2.2.2
-
       - name: Install OPAM dependencies
         run: opam install . --deps-only ${{ env.OPAM_FLAGS }}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,11 +18,7 @@ RUN if [ -n "$switch" ]; then opam switch create "$switch"; fi
 ## way) first the non-opam dependencies that are required and then the OPAM
 ## packages.
 
-## Remove these temporary pins once the current Menhir and Yojson
-## compatibility changes have landed.
-RUN opam pin add --no-action menhir 20240715 && \
-    opam pin add --no-action yojson 2.2.2 && \
-    opam depext -i menhir yojson ppx_deriving_yojson visitors
+RUN opam depext -i menhir yojson ppx_deriving_yojson visitors
 
 ## Install documentation dependencies. Disabled by default, but can be enabled
 ## with `--build-arg doc=true`.

--- a/src/ExtMenhirLib.ml
+++ b/src/ExtMenhirLib.ml
@@ -10,14 +10,6 @@
 (**************************************************************************)
 
 open Parser.MenhirInterpreter
-open MenhirLib.General
-
-let current_items parsing_state =
-  match Lazy.force (stack parsing_state) with
-  | Nil ->
-    []
-  | Cons (Element (s, _, _, _), _) ->
-    items s
 
 type 'a status =
   | AcceptedNow of 'a

--- a/src/c/CAPI.ml
+++ b/src/c/CAPI.ml
@@ -28,10 +28,6 @@ let ccst_of_json_program j =
       Location (start_p, end_p, aux v)
     | `List (`String k :: children) ->
       Node (k, aux' (`List children))
-    | `Variant (k, None) ->
-      Node (k, [||])
-    | `Variant (k, Some children) ->
-      Node (k, aux' children)
     | `String s ->
       Data s
     | `List l ->

--- a/src/jsonHelpers.ml
+++ b/src/jsonHelpers.ml
@@ -9,7 +9,8 @@
 (*  the POSIX standard. Please refer to the file COPYING for details.     *)
 (**************************************************************************)
 
-let rec json_filter_positions = function
+let rec json_filter_positions (json : Yojson.Safe.t) : Yojson.Safe.t =
+  match json with
   | `Assoc sjl ->
     if List.for_all (fun (s, _j) -> s = "value" || s = "position") sjl then
       let (_, j) = List.find (fun (s, _) -> s = "value") sjl in
@@ -25,13 +26,12 @@ let rec json_filter_positions = function
   | `List jl -> `List (List.map json_filter_positions jl)
   | `Null -> `Null
   | `String s -> `String s
-  | `Tuple jl -> `Tuple (List.map json_filter_positions jl)
-  | `Variant (s, None) -> `Variant (s, None)
-  | `Variant (s, Some j) -> `Variant (s, Some (json_filter_positions j))
+  | json -> json
+[@@warning "-11"]
 
 let convert_to_json simplified csts =
-  CSTSerializers.program_to_yojson csts
-  |> (if simplified then json_filter_positions else function x-> x)
+  let json : Yojson.Safe.t = CSTSerializers.program_to_yojson csts in
+  if simplified then json_filter_positions json else json
 
 let save_as_json simplified cout csts =
   convert_to_json simplified csts


### PR DESCRIPTION
Fixes #194.

This updates Morbig for the current OPAM dependency set:

- remove the unused `current_items` helper and its dependency on the removed `MenhirLib.General` module;
- make the JSON position filter compile with Yojson 3 while retaining compatibility with Yojson 2.2.

Validation:

- OCaml 4.14.2, Menhir 20260209, Yojson 3.0.0: `dune test` passes;
- OCaml 4.14.2, Menhir 20240715, Yojson 2.2.2: `dune test` passes;
- `dune fmt --check` passes.
