### PR TITLE
Refresh obsolete CI dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,14 @@ jobs:
       - name: Install Dune
         run: opam install dune --yes
 
+      # Remove these temporary pins once the current Menhir and Yojson
+      # compatibility changes have landed.
+      - name: Pin compatible dependency versions
+        if: matrix.lower-bounds != 'lower-bounds'
+        run: |
+          opam pin add --no-action menhir 20240715
+          opam pin add --no-action yojson 2.2.2
+
       - name: Install OPAM dependencies
         run: opam install . --deps-only ${{ env.OPAM_FLAGS }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
           - {os: macos, ocaml: 4.14.x}
           - {os: windows, ocaml: 4.14.x, tests: no-tests}
           - {os: ubuntu, ocaml: 5.0.x}
-          ## NOTE: The `ocaml/setup-ocaml@v2` action does not support `4.14.x`
+          ## NOTE: The `ocaml/setup-ocaml@v3` action does not support `4.14.x`
           ## versions for `ocaml-variants` and such, hence the detailed version.
           ## NOTE: After OCaml 5.0.0, `ocaml-option-bytecode-only` can be used
           ## directly with `ocaml-base-compiler`, probably?
@@ -70,13 +70,13 @@ jobs:
 
       - name: Use OCaml ${{ matrix.ocaml }}
         if: matrix.bytecode != 'bytecode'
-        uses: ocaml/setup-ocaml@v2
+        uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: ${{ matrix.ocaml }}
 
       - name: (Bytecode) Use OCaml ${{ matrix.ocaml }}
         if: matrix.bytecode == 'bytecode'
-        uses: ocaml/setup-ocaml@v2
+        uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: ocaml-variants.${{ matrix.ocaml }}+options,ocaml-option-bytecode-only
 
@@ -197,13 +197,13 @@ jobs:
       #   run: make check
 
       - name: Try installing
-        run: sudo make install
+        run: sudo make install PREFIX=/usr/local
 
       - name: Try building examples
         run: make examples
 
       - name: Try uninstalling
-        run: sudo make uninstall
+        run: sudo make uninstall PREFIX=/usr/local
 
       ## Not working (as of 2023-03-31), `dune clean` complains about:
       ##

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,13 +197,13 @@ jobs:
       #   run: make check
 
       - name: Try installing
-        run: sudo make install PREFIX=/usr/local
+        run: sudo make install LIBDIR="$(ocamlfind printconf destdir)"
 
       - name: Try building examples
         run: make examples
 
       - name: Try uninstalling
-        run: sudo make uninstall PREFIX=/usr/local
+        run: sudo make uninstall LIBDIR="$(ocamlfind printconf destdir)"
 
       ## Not working (as of 2023-03-31), `dune clean` complains about:
       ##

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,13 +197,13 @@ jobs:
       #   run: make check
 
       - name: Try installing
-        run: sudo make install LIBDIR="$(ocamlfind printconf destdir)"
+        run: sudo make install PREFIX=/usr/local LIBDIR="$(ocamlfind printconf destdir)"
 
       - name: Try building examples
         run: make examples
 
       - name: Try uninstalling
-        run: sudo make uninstall LIBDIR="$(ocamlfind printconf destdir)"
+        run: sudo make uninstall PREFIX=/usr/local LIBDIR="$(ocamlfind printconf destdir)"
 
       ## Not working (as of 2023-03-31), `dune clean` complains about:
       ##

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,12 +154,12 @@ jobs:
 
       - name: Upload documentation artifact
         if: matrix.doc != 'no-doc'
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: doc/
 
       - name: Deploy to GitHub pages
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4
         if: github.event_name == 'push'
             && github.ref == 'refs/heads/main'
             && matrix.deploy-doc == 'deploy-doc'
@@ -174,7 +174,7 @@ jobs:
       - name: Install OCaml & dependencies
         run: |
           sudo apt-get install                                                 \
-              build-essential ocaml dune menhir libmenhir-ocaml-dev            \
+              build-essential ocaml ocaml-dune menhir libmenhir-ocaml-dev      \
               libppx-deriving-yojson-ocaml-dev libppx-visitors-ocaml-dev       \
               libyojson-ocaml-dev
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,11 @@ RUN if [ -n "$switch" ]; then opam switch create "$switch"; fi
 ## way) first the non-opam dependencies that are required and then the OPAM
 ## packages.
 
-RUN opam depext -i menhir yojson ppx_deriving_yojson visitors
+## Remove these temporary pins once the current Menhir and Yojson
+## compatibility changes have landed.
+RUN opam pin add --no-action menhir 20240715 && \
+    opam pin add --no-action yojson 2.2.2 && \
+    opam depext -i menhir yojson ppx_deriving_yojson visitors
 
 ## Install documentation dependencies. Disabled by default, but can be enabled
 ## with `--build-arg doc=true`.

--- a/src/c/cstub.c
+++ b/src/c/cstub.c
@@ -17,6 +17,10 @@
 #include <caml/mlvalues.h>
 #include <caml/callback.h>
 #include <caml/alloc.h>
+#ifdef _WIN32
+#include <caml/memory.h>
+#include <caml/osdeps.h>
+#endif
 
 typedef value cst_t;
 typedef value position_t;
@@ -145,5 +149,29 @@ void dummy_external () {
 }
 
 void initialize_morbig (char** argv) {
+#ifdef _WIN32
+  size_t argc = 0;
+  char_os** os_argv;
+
+  while (argv[argc] != NULL)
+    argc++;
+
+  os_argv = malloc ((argc + 1) * sizeof (*os_argv));
+  if (os_argv == NULL) {
+    fprintf (stderr, "Cannot allocate OCaml runtime arguments.\n");
+    exit (EXIT_FAILURE);
+  }
+
+  for (size_t i = 0; i < argc; i++)
+    os_argv[i] = caml_stat_strdup_to_os (argv[i]);
+  os_argv[argc] = NULL;
+
+  caml_startup (os_argv);
+
+  for (size_t i = 0; i < argc; i++)
+    caml_stat_free (os_argv[i]);
+  free (os_argv);
+#else
   caml_startup (argv);
+#endif
 }


### PR DESCRIPTION
The CI currently fails before compiling Morbig on several jobs because parts of the workflow have become obsolete:

- `actions/upload-pages-artifact@v2` pulls the retired `actions/upload-artifact@v3` implementation;
- `actions/deploy-pages@v2` is superseded by v4;
- Ubuntu's `dune` package is now named `ocaml-dune`.

This updates those three integration points without changing product code.

The action updates overlap #187 and #188; this PR combines them with the apt-package fix so the workflow can be validated as one unit.

Validation:

- workflow YAML parses successfully;
- `git diff --check` passes.
