### PR TITLE
Exercise singleton lists in bd test

### DIFF
--- a/tests/unit/extPervasives.ml
+++ b/tests/unit/extPervasives.ml
@@ -65,10 +65,10 @@ module List = struct
       QCheck.(
         Test.make
           ~count:1000
-          ~name:"List.(bd @ [tl] = id)"
+          ~name:"List.(bd @ [ft] = id)"
           (list int)
           (fun l ->
-             assume (List.compare_length_with l 2 >= 0);
+             assume (List.compare_length_with l 1 >= 0);
              l = MEPL.(bd l @ [ft l])
           )
       )


### PR DESCRIPTION
Fixes #174.

The `bd`/`ft` reconstruction property only generated lists with at least two elements, although both helpers are defined for singleton lists. This extends the property to every non-empty list so the boundary case is exercised.

It also corrects the test name from `tl` to `ft`, matching the helper used by the property.

Validation:

- `dune test tests/unit --force` passes (15 tests);
- `make check` passes;
- `git diff --check` passes.