### PR TITLE
Upload a single Pages artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,7 +153,9 @@ jobs:
         run: opam exec -- make doc
 
       - name: Upload documentation artifact
-        if: matrix.doc != 'no-doc'
+        if: github.event_name == 'push'
+            && github.ref == 'refs/heads/main'
+            && matrix.deploy-doc == 'deploy-doc'
         uses: actions/upload-pages-artifact@v3
         with:
           path: doc/


### PR DESCRIPTION
The CI badge is currently red even though all builds and tests pass because the documentation jobs upload multiple artifacts named `github-pages`. The `deploy-pages` action refuses to deploy when more than one matching artifact exists.

This restricts the Pages artifact upload to the single `deploy-doc` job on pushes to `main`. Other documentation jobs continue to build the documentation without publishing duplicate deployment artifacts.

Validation:

- workflow YAML parses successfully;
- `git diff --check` passes.

After this PR is merged, the next push workflow on `main` should deploy Pages successfully and restore the CI badge.